### PR TITLE
feat: 카테고리 상품 목록 조회 , 상세 보기 기능 구현 

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -55,4 +55,6 @@ public class CartService {
         return "";
     }
 
+
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -1,12 +1,14 @@
 package kkakka.mainservice.cart.application;
 
 import kkakka.mainservice.cart.domain.Cart;
+import kkakka.mainservice.cart.domain.CartItem;
 import kkakka.mainservice.cart.domain.repository.CartItemRepository;
 import kkakka.mainservice.cart.domain.repository.CartRepository;
 import kkakka.mainservice.cart.ui.dto.CartRequestDto;
+import kkakka.mainservice.member.domain.Member;
+import kkakka.mainservice.member.domain.repository.MemberRepository;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -14,33 +16,42 @@ import java.util.Optional;
 @Service
 public class CartService {
 
-    CartRepository cartRepository;
-    CartItemRepository cartItemRepository;
-    ProductRepository productRepository;
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
 
-    @Autowired
-    public CartService(CartRepository cartRepository, CartItemRepository cartItemRepository, ProductRepository productRepository) {
+    public CartService(CartRepository cartRepository, CartItemRepository cartItemRepository, ProductRepository productRepository
+            , MemberRepository memberRepository) {
         this.cartRepository = cartRepository;
         this.cartItemRepository = cartItemRepository;
         this.productRepository = productRepository;
+        this.memberRepository = memberRepository;
     }
 
     public String saveCartItem(CartRequestDto cartItem) {
+
+        /* 테스트 데이터 */
+        Optional<Member> member = memberRepository.findById(cartItem.getMemberId());
 
         /* 로그인 상태 체크 */
 
         /* 장바구니 존재 유무 체크 ex) 장바구니에 담아둔 아이템 있는지 */
         Cart cart = new Cart();
-//        cart = cartRepository.findByMemberId(cartItem.getMemberId());
+        cart = cartRepository.findByMemberId(cartItem.getMemberId());
         if (cart == null) {
-//            cartRepository.save(member)
+            cartRepository.save(new Cart(member.get()));
+            cart = cartRepository.findByMemberId(cartItem.getMemberId());
         }
 
         /* 현재 장바구니에 동일한 상품 있는지 체크 */
+        CartItem item = cartItemRepository.findByMemberIdandProductId(member.get().getId(), cartItem.getProductId()); // Test용 Member
+//        System.out.println(item.toString());
 
         /* 장바구니 아이템 추가 */
         Optional<Product> product = productRepository.findById(cartItem.getProductId());
-//        cartItemRepository.save(member,product.get(),)
+
+        cartItemRepository.save(new CartItem(cart, product.get(), cartItem.getQuantity()));
 
         return "";
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -29,29 +29,28 @@ public class CartService {
         this.memberRepository = memberRepository;
     }
 
-    public String saveCartItem(CartRequestDto cartItem) {
+    public String saveCartItem(CartRequestDto cartRequestDto) {
 
         /* 테스트 데이터 */
-        Optional<Member> member = memberRepository.findById(cartItem.getMemberId());
+        Optional<Member> member = memberRepository.findById(cartRequestDto.getMemberId());
 
         /* 로그인 상태 체크 */
 
         /* 장바구니 존재 유무 체크 ex) 장바구니에 담아둔 아이템 있는지 */
         Cart cart = new Cart();
-        cart = cartRepository.findByMemberId(cartItem.getMemberId());
+        cart = cartRepository.findByMemberId(cartRequestDto.getMemberId());
         if (cart == null) {
             cartRepository.save(new Cart(member.get()));
-            cart = cartRepository.findByMemberId(cartItem.getMemberId());
+            cart = cartRepository.findByMemberId(cartRequestDto.getMemberId());
         }
 
         /* 현재 장바구니에 동일한 상품 있는지 체크 */
-        CartItem item = cartItemRepository.findByMemberIdandProductId(member.get().getId(), cartItem.getProductId()); // Test용 Member
+        CartItem item = cartItemRepository.findByMemberIdandProductId(member.get().getId(), cartRequestDto.getProductId()); // Test용 Member
 //        System.out.println(item.toString());
 
         /* 장바구니 아이템 추가 */
-        Optional<Product> product = productRepository.findById(cartItem.getProductId());
-
-        cartItemRepository.save(new CartItem(cart, product.get(), cartItem.getQuantity()));
+        Optional<Product> product = productRepository.findById(cartRequestDto.getProductId());
+        cartItemRepository.save(new CartItem(cart, product.get(), cartRequestDto.getQuantity()));
 
         return "";
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -1,7 +1,48 @@
 package kkakka.mainservice.cart.application;
 
+import kkakka.mainservice.cart.domain.Cart;
+import kkakka.mainservice.cart.domain.repository.CartItemRepository;
+import kkakka.mainservice.cart.domain.repository.CartRepository;
+import kkakka.mainservice.cart.ui.dto.CartRequestDto;
+import kkakka.mainservice.product.domain.Product;
+import kkakka.mainservice.product.domain.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 public class CartService {
+
+    CartRepository cartRepository;
+    CartItemRepository cartItemRepository;
+    ProductRepository productRepository;
+
+    @Autowired
+    public CartService(CartRepository cartRepository, CartItemRepository cartItemRepository, ProductRepository productRepository) {
+        this.cartRepository = cartRepository;
+        this.cartItemRepository = cartItemRepository;
+        this.productRepository = productRepository;
+    }
+
+    public String saveCartItem(CartRequestDto cartItem) {
+
+        /* 로그인 상태 체크 */
+
+        /* 장바구니 존재 유무 체크 ex) 장바구니에 담아둔 아이템 있는지 */
+        Cart cart = new Cart();
+//        cart = cartRepository.findByMemberId(cartItem.getMemberId());
+        if (cart == null) {
+//            cartRepository.save(member)
+        }
+
+        /* 현재 장바구니에 동일한 상품 있는지 체크 */
+
+        /* 장바구니 아이템 추가 */
+        Optional<Product> product = productRepository.findById(cartItem.getProductId());
+//        cartItemRepository.save(member,product.get(),)
+
+        return "";
+    }
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -30,8 +30,4 @@ public class Cart {
     public Cart(Member member) {
         this(null, null, member);
     }
-
-    public static Cart create(Member member) {
-        return new Cart(null, null, member);
-    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -11,7 +11,6 @@ public class Cart {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long Id;
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-    @OneToOne
-    private Member member;
+//    @OneToOne
+//    private Member member;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.cart.domain;
 
 import kkakka.mainservice.member.domain.Member;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -10,15 +11,20 @@ import java.util.List;
 @Entity
 @Table(name = "cart")
 @NoArgsConstructor
+@Getter
 public class Cart {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CART_ID")
-    private Long Id;
+    private Long id;
 
     @OneToMany(mappedBy = "cart")
-    List<CartItem> cartItems = new ArrayList<>();
+    private List<CartItem> cartItems = new ArrayList<>();
 
-//    @OneToOne
-//    private Member member;
+    @OneToOne
+    private Member member;
+
+    public Cart(Member member) {
+        this.member = member;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -1,15 +1,23 @@
 package kkakka.mainservice.cart.domain;
 
 import kkakka.mainservice.member.domain.Member;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "cart")
+@NoArgsConstructor
 public class Cart {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CART_ID")
     private Long Id;
+
+    @OneToMany(mappedBy = "cart")
+    List<CartItem> cartItems = new ArrayList<>();
 
 //    @OneToOne
 //    private Member member;

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -1,4 +1,12 @@
 package kkakka.mainservice.cart.domain;
 
+import javax.persistence.*;
+
+@Entity
+@Table(name = "cart")
 public class Cart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+    
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -1,6 +1,8 @@
 package kkakka.mainservice.cart.domain;
 
 import kkakka.mainservice.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,7 @@ import java.util.List;
 @Entity
 @Table(name = "cart")
 @NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class Cart {
 
@@ -25,6 +28,10 @@ public class Cart {
     private Member member;
 
     public Cart(Member member) {
-        this.member = member;
+        this(null, null, member);
+    }
+
+    public static Cart create(Member member) {
+        return new Cart(null, null, member);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -1,5 +1,7 @@
 package kkakka.mainservice.cart.domain;
 
+import kkakka.mainservice.member.domain.Member;
+
 import javax.persistence.*;
 
 @Entity
@@ -8,5 +10,8 @@ public class Cart {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long Id;
-    
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne
+    private Member member;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -1,24 +1,35 @@
 package kkakka.mainservice.cart.domain;
 
 import kkakka.mainservice.product.domain.Product;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Table(name = "cartitem")
+@NoArgsConstructor
 public class CartItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CART_ID")
     private Cart cart;
     @OneToOne
     @JoinColumn(name = "id")
     private Product product;
 
+    private Integer coupon_id;
+
     @Column(nullable = false)
     private Integer quantity;
     private Integer price;
+
+    public CartItem(Cart cart, Product product, Integer quantity) {
+        this.cart = cart;
+        this.product = product;
+        this.quantity = quantity;
+    }
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -1,5 +1,7 @@
 package kkakka.mainservice.cart.domain;
 
+import kkakka.mainservice.product.domain.Product;
+
 import javax.persistence.*;
 
 @Entity
@@ -11,6 +13,9 @@ public class CartItem {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Cart cart;
+    @OneToOne
+    @JoinColumn(name = "id")
+    private Product product;
 
     @Column(nullable = false)
     private Integer quantity;

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -1,0 +1,19 @@
+package kkakka.mainservice.cart.domain;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "cartitem")
+public class CartItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Cart cart;
+
+    @Column(nullable = false)
+    private Integer quantity;
+    private Integer price;
+
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.cart.domain;
 
 import kkakka.mainservice.product.domain.Product;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -8,16 +9,15 @@ import javax.persistence.*;
 @Entity
 @Table(name = "cartitem")
 @NoArgsConstructor
+@Getter
 public class CartItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "CART_ID")
     private Cart cart;
-    @OneToOne
-    @JoinColumn(name = "id")
+    @ManyToOne(fetch = FetchType.LAZY)
     private Product product;
 
     private Integer coupon_id;
@@ -32,4 +32,13 @@ public class CartItem {
         this.quantity = quantity;
     }
 
+    @Override
+    public String toString() {
+        return "CartItem{" +
+                "id=" + id +
+                ", coupon_id=" + coupon_id +
+                ", quantity=" + quantity +
+                ", price=" + price +
+                '}';
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
@@ -1,0 +1,8 @@
+package kkakka.mainservice.cart.domain.repository;
+
+import kkakka.mainservice.cart.domain.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
     @Query(value = "SELECT c from CartItem c join fetch c.cart where c.cart.member.id = :memberId and c.product.id = :productId")
     CartItem findByMemberIdandProductId(@Param("memberId") Long memberId, @Param("productId") Long ProductId);
+
+    @Query(value = "SELECT c from CartItem c join fetch c.cart where c.cart.member.id = :memberId")
+    List<CartItem> findAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
@@ -2,7 +2,11 @@ package kkakka.mainservice.cart.domain.repository;
 
 import kkakka.mainservice.cart.domain.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
+    @Query(value = "SELECT c from CartItem c join fetch c.cart where c.cart.member.id = :memberId and c.product.id = :productId")
+    CartItem findByMemberIdandProductId(@Param("memberId") Long memberId, @Param("productId") Long ProductId);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartRepository.java
@@ -4,6 +4,6 @@ import kkakka.mainservice.cart.domain.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
-//    Cart findByMemberId(Long id);
+    Cart findByMemberId(Long id);
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartRepository.java
@@ -1,4 +1,9 @@
 package kkakka.mainservice.cart.domain.repository;
 
-public interface CartRepository {
+import kkakka.mainservice.cart.domain.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+//    Cart findByMemberId(Long id);
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
@@ -24,4 +24,6 @@ public class CartController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body("success");
     }
+
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
@@ -1,9 +1,27 @@
 package kkakka.mainservice.cart.ui;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import kkakka.mainservice.cart.application.CartService;
+import kkakka.mainservice.cart.ui.dto.CartRequestDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/cart")
 public class CartController {
+
+    CartService cartService;
+
+    @Autowired
+    public CartController(CartService cartService) {
+        this.cartService = cartService;
+    }
+
+    @PostMapping("/carts")
+    public ResponseEntity<String> saveCartItem(@RequestBody CartRequestDto cartItem) {
+        cartService.saveCartItem(cartItem);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body("success");
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
@@ -19,8 +19,8 @@ public class CartController {
     }
 
     @PostMapping("/carts")
-    public ResponseEntity<String> saveCartItem(@RequestBody CartRequestDto cartItem) {
-        cartService.saveCartItem(cartItem);
+    public ResponseEntity<String> saveCartItem(@RequestBody CartRequestDto cartRequestDto) {
+        cartService.saveCartItem(cartRequestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body("success");
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartRequestDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartRequestDto.java
@@ -2,11 +2,22 @@ package kkakka.mainservice.cart.ui.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class CartRequestDto {
+
     private Long memberId;
     private Long productId;
     private Integer quantity;
+
+    @Override
+    public String toString() {
+        return "CartRequestDto{" +
+                "memberId=" + memberId +
+                ", productId=" + productId +
+                ", quantity=" + quantity +
+                '}';
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartRequestDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartRequestDto.java
@@ -1,0 +1,12 @@
+package kkakka.mainservice.cart.ui.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CartRequestDto {
+    private Long memberId;
+    private Long productId;
+    private Integer quantity;
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -11,9 +11,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class CategoryService {
 
-    CategoryRepository categoryRepository;
+    private final CategoryRepository categoryRepository;
 
-    @Autowired
     public CategoryService(CategoryRepository categoryRepository) {
         this.categoryRepository = categoryRepository;
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -3,16 +3,10 @@ package kkakka.mainservice.category.application;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.category.ui.dto.ResponseCategory;
 import kkakka.mainservice.product.domain.Product;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 @Service
 public class CategoryService {
@@ -26,26 +20,15 @@ public class CategoryService {
 
     public Page<ResponseCategory> getProductsByCategoryId(Long categoryId, Pageable pageable) {
 
-
-        Page<Product> products = categoryRepository.findByCategoryId(categoryId,pageable);
-
-        ModelMapper mapper = new ModelMapper();
-        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-
+        Page<Product> products = categoryRepository.findByCategoryId(categoryId, pageable);
         Page<ResponseCategory> responseCategories = products.map(p ->
-                        new ResponseCategory(p.getProductId(),
-                                p.getName(),
-                                p.getPrice(),
-                                p.getImage_url(),
-                                p.getDiscount(),
-                                p.getRegistered_at()
-                        ));
-
-//        List<ResponseCategory> result = new ArrayList<>();
-//        products.forEach(v -> {
-//            result.add(mapper.map(v, ResponseCategory.class));
-//        });
-
+                new ResponseCategory(p.getProductId(),
+                        p.getName(),
+                        p.getPrice(),
+                        p.getImage_url(),
+                        p.getDiscount(),
+                        p.getRegistered_at()
+                ));
         return responseCategories;
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -3,7 +3,6 @@ package kkakka.mainservice.category.application;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.category.ui.dto.ResponseCategoryProducts;
 import kkakka.mainservice.product.domain.Product;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -24,7 +23,7 @@ public class CategoryService {
                 new ResponseCategoryProducts(p.getId(),
                         p.getName(),
                         p.getPrice(),
-                        p.getImage_url(),
+                        p.getImageUrl(),
                         p.getDiscount(),
                         p.getRegistered_at()
                 ));

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -1,7 +1,7 @@
 package kkakka.mainservice.category.application;
 
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
-import kkakka.mainservice.category.ui.dto.ResponseCategory;
+import kkakka.mainservice.category.ui.dto.ResponseCategoryProducts;
 import kkakka.mainservice.product.domain.Product;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -18,17 +18,17 @@ public class CategoryService {
         this.categoryRepository = categoryRepository;
     }
 
-    public Page<ResponseCategory> getProductsByCategoryId(Long categoryId, Pageable pageable) {
+    public Page<ResponseCategoryProducts> getProductsByCategoryId(Long categoryId, Pageable pageable) {
 
         Page<Product> products = categoryRepository.findByCategoryId(categoryId, pageable);
-        Page<ResponseCategory> responseCategories = products.map(p ->
-                new ResponseCategory(p.getProductId(),
+        Page<ResponseCategoryProducts> responseCategoryProducts = products.map(p ->
+                new ResponseCategoryProducts(p.getId(),
                         p.getName(),
                         p.getPrice(),
                         p.getImage_url(),
                         p.getDiscount(),
                         p.getRegistered_at()
                 ));
-        return responseCategories;
+        return responseCategoryProducts;
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -20,13 +20,7 @@ public class CategoryService {
 
         Page<Product> products = categoryRepository.findByCategoryId(categoryId, pageable);
         Page<ResponseCategoryProducts> responseCategoryProducts = products.map(p ->
-                new ResponseCategoryProducts(p.getId(),
-                        p.getName(),
-                        p.getPrice(),
-                        p.getImageUrl(),
-                        p.getDiscount(),
-                        p.getRegistered_at()
-                ));
+                ResponseCategoryProducts.from(p));
         return responseCategoryProducts;
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -1,0 +1,4 @@
+package kkakka.mainservice.category.application;
+
+public class CategoryService {
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -1,4 +1,38 @@
 package kkakka.mainservice.category.application;
 
+import kkakka.mainservice.category.domain.repository.CategoryRepository;
+import kkakka.mainservice.category.ui.dto.ResponseCategory;
+import kkakka.mainservice.product.domain.Product;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
 public class CategoryService {
+
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<ResponseCategory> getProductsByCategoryId(Long categoryId) {
+
+        List<Product> products = categoryRepository.findByCategoryId(categoryId);
+
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+
+        List<ResponseCategory> result = new ArrayList<>();
+        products.forEach(v -> {
+            result.add(mapper.map(v, ResponseCategory.class));
+        });
+
+        return result;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/application/CategoryService.java
@@ -6,9 +6,12 @@ import kkakka.mainservice.product.domain.Product;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @Service
@@ -21,18 +24,28 @@ public class CategoryService {
         this.categoryRepository = categoryRepository;
     }
 
-    public List<ResponseCategory> getProductsByCategoryId(Long categoryId) {
+    public Page<ResponseCategory> getProductsByCategoryId(Long categoryId, Pageable pageable) {
 
-        List<Product> products = categoryRepository.findByCategoryId(categoryId);
+
+        Page<Product> products = categoryRepository.findByCategoryId(categoryId,pageable);
 
         ModelMapper mapper = new ModelMapper();
         mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
 
-        List<ResponseCategory> result = new ArrayList<>();
-        products.forEach(v -> {
-            result.add(mapper.map(v, ResponseCategory.class));
-        });
+        Page<ResponseCategory> responseCategories = products.map(p ->
+                        new ResponseCategory(p.getProductId(),
+                                p.getName(),
+                                p.getPrice(),
+                                p.getImage_url(),
+                                p.getDiscount(),
+                                p.getRegistered_at()
+                        ));
 
-        return result;
+//        List<ResponseCategory> result = new ArrayList<>();
+//        products.forEach(v -> {
+//            result.add(mapper.map(v, ResponseCategory.class));
+//        });
+
+        return responseCategories;
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -17,8 +17,7 @@ import java.util.List;
 public class Category {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CATEGORY_ID", nullable = false)
-    private Long categoryId;
+    private Long id;
 
     @Column(nullable = false)
     private String name;

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.category.domain;
 
 import kkakka.mainservice.product.domain.Product;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -8,9 +9,11 @@ import java.util.List;
 
 @Entity
 @Table(name = "category")
+@NoArgsConstructor
 public class Category {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CATEGORY_ID")
     private Long categoryId;
 
     @Column(nullable = false)
@@ -18,4 +21,12 @@ public class Category {
 
     @OneToMany(mappedBy = "category")
     private List<Product> productList = new ArrayList<Product>();
+
+    public List<Product> getProductList() {
+        return productList;
+    }
+
+    public Category(String name) {
+        this.name = name;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -17,7 +17,6 @@ import java.util.List;
 public class Category {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CATEGORY_ID")
     private Long id;
 
     @Column(nullable = false)

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -1,0 +1,21 @@
+package kkakka.mainservice.category.domain;
+
+import kkakka.mainservice.product.domain.Product;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "category")
+public class Category {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "category")
+    private List<Product> productList = new ArrayList<Product>();
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -1,6 +1,8 @@
 package kkakka.mainservice.category.domain;
 
 import kkakka.mainservice.product.domain.Product;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
@@ -10,28 +12,18 @@ import java.util.List;
 @Entity
 @Table(name = "category")
 @NoArgsConstructor
+@AllArgsConstructor
+@Getter
 public class Category {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "CATEGORY_ID")
+    @Column(name = "CATEGORY_ID", nullable = false)
     private Long categoryId;
 
     @Column(nullable = false)
     private String name;
 
-    @OneToMany(mappedBy = "category")
-    private List<Product> productList = new ArrayList<Product>();
-
-    public List<Product> getProductList() {
-        return productList;
-    }
-
     public Category(String name) {
-        this.name = name;
-    }
-
-    public Category(Long categoryId, String name) {
-        this.categoryId = categoryId;
         this.name = name;
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class Category {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "CATEGORY_ID")
     private Long id;
 
     @Column(nullable = false)

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/Category.java
@@ -29,4 +29,9 @@ public class Category {
     public Category(String name) {
         this.name = name;
     }
+
+    public Category(Long categoryId, String name) {
+        this.categoryId = categoryId;
+        this.name = name;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
@@ -10,8 +10,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-    @Query(value = "SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId"
-            , countQuery = "SELECT count(p) FROM Product p where p.category.categoryId = :categoryId")
+    @Query(value = "SELECT p from Product p join fetch p.category where p.category.id = :categoryId"
+            , countQuery = "SELECT count(p) FROM Product p where p.category.id = :categoryId")
     Page<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
@@ -8,15 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-//    @Query("SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId")
-//    List<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
-
     @Query(value = "SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId"
-        ,countQuery = "SELECT count(p) FROM Product p where p.category.categoryId = :categoryId")
+            , countQuery = "SELECT count(p) FROM Product p where p.category.categoryId = :categoryId")
     Page<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package kkakka.mainservice.category.domain.repository;
 
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.product.domain.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,7 +12,10 @@ import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
+//    @Query("SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId")
+//    List<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
+
     @Query("SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId")
-    List<Product> findByCategoryId(@Param("categoryId") Long categoryId);
+    Page<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
@@ -15,7 +15,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 //    @Query("SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId")
 //    List<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
-    @Query("SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId")
+    @Query(value = "SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId"
+        ,countQuery = "SELECT count(p) FROM Product p where p.category.categoryId = :categoryId")
     Page<Product> findByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
@@ -1,0 +1,4 @@
+package kkakka.mainservice.category.domain.repository;
+
+public interface CategoryRepository {
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/domain/repository/CategoryRepository.java
@@ -1,4 +1,16 @@
 package kkakka.mainservice.category.domain.repository;
 
-public interface CategoryRepository {
+import kkakka.mainservice.category.domain.Category;
+import kkakka.mainservice.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT p from Product p join fetch p.category where p.category.categoryId = :categoryId")
+    List<Product> findByCategoryId(@Param("categoryId") Long categoryId);
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -4,10 +4,8 @@ import kkakka.mainservice.category.application.CategoryService;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.category.ui.dto.ResponseCategoryProducts;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,7 +42,7 @@ public class CategoryController {
 
     @GetMapping("/{categoryId}")
     public ResponseEntity<List<ResponseCategoryProducts>> getCategories(@PathVariable("categoryId") Long categoryId,
-                                                                        @PageableDefault(size = 2) Pageable pageable) {
+                                                                        Pageable pageable) {
         Page<ResponseCategoryProducts> result = categoryService.getProductsByCategoryId(categoryId, pageable);
 
         System.out.println("전체 페이지 수: " + result.getTotalPages());

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -4,11 +4,10 @@ import kkakka.mainservice.category.application.CategoryService;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.category.ui.dto.ResponseCategory;
-import kkakka.mainservice.product.domain.Product;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,17 +44,14 @@ public class CategoryController {
     }
 
     @GetMapping("/{categoryId}")
-    public ResponseEntity<List<ResponseCategory>> getCategories(@PathVariable("categoryId") Long categoryId) {
-        Pageable pageable = PageRequest.of(0,3);
+    public ResponseEntity<List<ResponseCategory>> getCategories(@PathVariable("categoryId") Long categoryId,
+                                                                @PageableDefault(size = 2) Pageable pageable) {
+        Page<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId, pageable);
 
-//        List<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId,pageable);
-        Page<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId,pageable);
-
-        System.out.println("getTotalPages: " + result.getTotalPages());
-        System.out.println("getTotalElements: " + result.getTotalElements());
-        System.out.println("getNumber: " + result.getNumber());
+        System.out.println("전체 페이지 수: " + result.getTotalPages());
+        System.out.println("전체 상품목록 수: " + result.getTotalElements());
+        System.out.println("현재 페이지(기본0) : " + result.getNumber());
         System.out.println("hasNext: " + result.hasNext());
-
 
         return ResponseEntity.status(HttpStatus.OK).body(result.getContent());
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -40,17 +40,4 @@ public class CategoryController {
         categoryRepository.save(new Category("박스과자"));
     }
 
-    @GetMapping("/{categoryId}")
-    public ResponseEntity<List<ResponseCategoryProducts>> getCategories(@PathVariable("categoryId") Long categoryId,
-                                                                        Pageable pageable) {
-        Page<ResponseCategoryProducts> result = categoryService.getProductsByCategoryId(categoryId, pageable);
-
-        System.out.println("전체 페이지 수: " + result.getTotalPages());
-        System.out.println("전체 상품목록 수: " + result.getTotalElements());
-        System.out.println("현재 페이지(기본0) : " + result.getNumber());
-        System.out.println("hasNext: " + result.hasNext());
-
-        return ResponseEntity.status(HttpStatus.OK).body(result.getContent());
-    }
-
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -1,9 +1,52 @@
 package kkakka.mainservice.category.ui;
 
+import kkakka.mainservice.category.application.CategoryService;
+import kkakka.mainservice.category.domain.Category;
+import kkakka.mainservice.category.domain.repository.CategoryRepository;
+import kkakka.mainservice.category.ui.dto.ResponseCategory;
+import kkakka.mainservice.product.domain.Product;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
 
 @RestController
 @RequestMapping("/category")
 public class CategoryController {
+
+    CategoryRepository categoryRepository;
+    CategoryService categoryService;
+
+    @Autowired
+    public CategoryController(CategoryRepository categoryRepository, CategoryService categoryService) {
+        this.categoryRepository = categoryRepository;
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("/health_check")
+    public String status() {
+        return "It's Working in Category Service";
+    }
+
+    @PostConstruct
+    public void init() {
+        categoryRepository.save(new Category("비스킷/샌드"));
+        categoryRepository.save(new Category("스낵/봉지과자"));
+        categoryRepository.save(new Category("박스과자"));
+    }
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<List<ResponseCategory>> getCategories(@PathVariable("categoryId") Long categoryId) {
+        List<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -22,10 +22,9 @@ import java.util.List;
 @RequestMapping("/category")
 public class CategoryController {
 
-    CategoryRepository categoryRepository;
-    CategoryService categoryService;
+    private final CategoryRepository categoryRepository;
+    private final CategoryService categoryService;
 
-    @Autowired
     public CategoryController(CategoryRepository categoryRepository, CategoryService categoryService) {
         this.categoryRepository = categoryRepository;
         this.categoryService = categoryService;

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -3,7 +3,7 @@ package kkakka.mainservice.category.ui;
 import kkakka.mainservice.category.application.CategoryService;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
-import kkakka.mainservice.category.ui.dto.ResponseCategory;
+import kkakka.mainservice.category.ui.dto.ResponseCategoryProducts;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,9 +44,9 @@ public class CategoryController {
     }
 
     @GetMapping("/{categoryId}")
-    public ResponseEntity<List<ResponseCategory>> getCategories(@PathVariable("categoryId") Long categoryId,
-                                                                @PageableDefault(size = 2) Pageable pageable) {
-        Page<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId, pageable);
+    public ResponseEntity<List<ResponseCategoryProducts>> getCategories(@PathVariable("categoryId") Long categoryId,
+                                                                        @PageableDefault(size = 2) Pageable pageable) {
+        Page<ResponseCategoryProducts> result = categoryService.getProductsByCategoryId(categoryId, pageable);
 
         System.out.println("전체 페이지 수: " + result.getTotalPages());
         System.out.println("전체 상품목록 수: " + result.getTotalElements());

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -6,6 +6,9 @@ import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.category.ui.dto.ResponseCategory;
 import kkakka.mainservice.product.domain.Product;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -44,9 +46,18 @@ public class CategoryController {
 
     @GetMapping("/{categoryId}")
     public ResponseEntity<List<ResponseCategory>> getCategories(@PathVariable("categoryId") Long categoryId) {
-        List<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId);
+        Pageable pageable = PageRequest.of(0,3);
 
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+//        List<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId,pageable);
+        Page<ResponseCategory> result = categoryService.getProductsByCategoryId(categoryId,pageable);
+
+        System.out.println("getTotalPages: " + result.getTotalPages());
+        System.out.println("getTotalElements: " + result.getTotalElements());
+        System.out.println("getNumber: " + result.getNumber());
+        System.out.println("hasNext: " + result.hasNext());
+
+
+        return ResponseEntity.status(HttpStatus.OK).body(result.getContent());
     }
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/CategoryController.java
@@ -1,0 +1,9 @@
+package kkakka.mainservice.category.ui;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/category")
+public class CategoryController {
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategory.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategory.java
@@ -1,10 +1,12 @@
 package kkakka.mainservice.category.ui.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.Date;
 
 @Data
+@AllArgsConstructor
 public class ResponseCategory {
     private Long productId;
     private String name;

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategory.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategory.java
@@ -10,8 +10,8 @@ import java.util.Date;
 public class ResponseCategory {
     private Long productId;
     private String name;
-    private int price;
+    private Integer price;
     private String image_url;
-    private int discount;
+    private Integer discount;
     private Date registered_at;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategory.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategory.java
@@ -1,0 +1,15 @@
+package kkakka.mainservice.category.ui.dto;
+
+import lombok.Data;
+
+import java.util.Date;
+
+@Data
+public class ResponseCategory {
+    private Long productId;
+    private String name;
+    private int price;
+    private String image_url;
+    private int discount;
+    private Date registered_at;
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
@@ -1,7 +1,7 @@
 package kkakka.mainservice.category.ui.dto;
 
+import kkakka.mainservice.product.domain.Product;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 
 import java.util.Date;
@@ -16,4 +16,13 @@ public class ResponseCategoryProducts {
     private String imageUrl;
     private Integer discount;
     private Date registeredAt;
+
+    public static ResponseCategoryProducts from(Product product) {
+        return new ResponseCategoryProducts(product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getImageUrl(),
+                product.getDiscount(),
+                product.getRegistered_at());
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
@@ -7,8 +7,8 @@ import java.util.Date;
 
 @Data
 @AllArgsConstructor
-public class ResponseCategory {
-    private Long productId;
+public class ResponseCategoryProducts {
+    private Long id;
     private String name;
     private Integer price;
     private String image_url;

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
@@ -2,16 +2,18 @@ package kkakka.mainservice.category.ui.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 
 import java.util.Date;
 
-@Data
+@Getter
 @AllArgsConstructor
 public class ResponseCategoryProducts {
+
     private Long id;
     private String name;
     private Integer price;
-    private String image_url;
-    private Integer discount;
-    private Date registered_at;
+    private String imageUrl;
+    private Integer disCount;
+    private Date registeredAt;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
@@ -14,6 +14,6 @@ public class ResponseCategoryProducts {
     private String name;
     private Integer price;
     private String imageUrl;
-    private Integer disCount;
+    private Integer discount;
     private Date registeredAt;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/config/MapperConfig.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/config/MapperConfig.java
@@ -1,0 +1,17 @@
+package kkakka.mainservice.common.config;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        return mapper;
+    }
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/config/WebConfig.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/config/WebConfig.java
@@ -1,0 +1,17 @@
+package kkakka.mainservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer customizer(){
+        return p -> {
+            p.setOneIndexedParameters(true);
+            p.setMaxPageSize(1);
+        };
+    }
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/domain/Member.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/domain/Member.java
@@ -1,4 +1,54 @@
 package kkakka.mainservice.member.domain;
 
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+//import kkakka.mainservice.auth.application.UserProfile;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @Embedded
+//    private Provider provider;
+
+    private String name;
+    private String email;
+    private String phone;
+    private String address;
+    private String ageGroup;
+
+//    @Enumerated(EnumType.STRING)
+//    private Grade grade;
+
+//    public static Member create(Long id, Provider provider, String name, String email, String phone,
+//                                String address, String ageGroup, Grade grade) {
+//        return new Member(id, provider, name, email, phone, address, ageGroup, grade);
+//    }
+//
+//    public static Member create(UserProfile userProfile, Provider provider) {
+//        return new Member(null, provider, userProfile.getName(),
+//                userProfile.getEmail(), userProfile.getPhone(), "",
+//                userProfile.getAgeGroup(), Grade.BRONZE);
+//    }
+
+    /* 테스트용 생성자 */
+    public Member(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/domain/repository/MemberRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/domain/repository/MemberRepository.java
@@ -1,4 +1,7 @@
 package kkakka.mainservice.member.domain.repository;
 
-public interface MemberRepository {
+import kkakka.mainservice.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/ui/MemberController.java
@@ -1,15 +1,27 @@
 package kkakka.mainservice.member.ui;
 
+import kkakka.mainservice.member.domain.Member;
+import kkakka.mainservice.member.domain.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.PostConstruct;
 
 @RestController
 @RequestMapping("/member")
 public class MemberController {
 
+    @Autowired
+    MemberRepository memberRepository;
     @GetMapping("/health_check")
     public String status(){
         return "It's Working in Member Service";
+    }
+
+    @PostConstruct
+    public void init(){
+        memberRepository.save(new Member(1L,"신우주"));
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/application/ProductService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/application/ProductService.java
@@ -1,4 +1,32 @@
 package kkakka.mainservice.product.application;
 
+import kkakka.mainservice.product.domain.Product;
+import kkakka.mainservice.product.domain.repository.ProductRepository;
+import kkakka.mainservice.product.ui.dto.ProductResponseDto;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
 public class ProductService {
+
+    ProductRepository productRepository;
+
+    @Autowired
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public ProductResponseDto getProductByProductId(Long productId) {
+        Product productDetail = productRepository.findByProductId(productId);
+
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+        ProductResponseDto result = mapper.map(productDetail, ProductResponseDto.class);
+
+        result.setCategoryName(productDetail.getCategory().getName());
+
+        return result;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/application/ProductService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/application/ProductService.java
@@ -8,6 +8,8 @@ import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class ProductService {
 
@@ -18,14 +20,14 @@ public class ProductService {
         this.productRepository = productRepository;
     }
 
-    public ProductResponseDto getProductByProductId(Long productId) {
-        Product productDetail = productRepository.findByProductId(productId);
+    public ProductResponseDto getProductDetail(Long productId) {
+        Optional<Product> productDetail = productRepository.findById(productId);
 
         ModelMapper mapper = new ModelMapper();
         mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-        ProductResponseDto result = mapper.map(productDetail, ProductResponseDto.class);
+        ProductResponseDto result = mapper.map(productDetail.get(), ProductResponseDto.class);
 
-        result.setCategoryName(productDetail.getCategory().getName());
+        result.setCategoryName(productDetail.get().getCategory().getName());
 
         return result;
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/application/ProductService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/application/ProductService.java
@@ -1,5 +1,6 @@
 package kkakka.mainservice.product.application;
 
+import kkakka.mainservice.common.config.MapperConfig;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
 import kkakka.mainservice.product.ui.dto.ProductResponseDto;
@@ -21,12 +22,11 @@ public class ProductService {
     }
 
     public ProductResponseDto getProductDetail(Long productId) {
+
         Optional<Product> productDetail = productRepository.findById(productId);
 
-        ModelMapper mapper = new ModelMapper();
-        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-        ProductResponseDto result = mapper.map(productDetail.get(), ProductResponseDto.class);
-
+        ModelMapper mapper = new MapperConfig().modelMapper();
+        ProductResponseDto result = mapper.map(productDetail.get(), ProductResponseDto.class); // NPE 처리 필요
         result.setCategoryName(productDetail.get().getCategory().getName());
 
         return result;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -1,6 +1,8 @@
 package kkakka.mainservice.product.domain;
 
 import kkakka.mainservice.category.domain.Category;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
@@ -8,25 +10,32 @@ import java.util.Date;
 
 @Entity
 @Table(name = "product")
+@Data
+@NoArgsConstructor
 public class Product {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(nullable = false)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PRODUCT_ID")
+    private Long productId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CATEGORY_ID")
+    private Category category;
+
+    @Column(nullable = false, length = 255)
     private String name;
     private int price;
     private int stock;
-    private int discount;
+
+    @Column(nullable = true)
     private String image_url;
     private String detail_image_url;
     private String nutrition_info_url;
+    @ColumnDefault("0")
+    private int discount;
 
     @Column(nullable = false, updatable = false, insertable = false)
     @ColumnDefault(value = "CURRENT_TIMESTAMP")
     private Date registered_at;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "CATEGORY_ID")
-    private Category category;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -1,4 +1,32 @@
 package kkakka.mainservice.product.domain;
 
+import kkakka.mainservice.category.domain.Category;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "product")
 public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+    private int price;
+    private int stock;
+    private int discount;
+    private String image_url;
+    private String detail_image_url;
+    private String nutrition_info_url;
+
+    @Column(nullable = false, updatable = false, insertable = false)
+    @ColumnDefault(value = "CURRENT_TIMESTAMP")
+    private Date registered_at;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CATEGORY_ID")
+    private Category category;
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -38,4 +38,12 @@ public class Product {
     @ColumnDefault(value = "CURRENT_TIMESTAMP")
     private Date registered_at;
 
+    public Product(Category category, String name, int price, int stock, String image_url, String detail_image_url) {
+        this.category = category;
+        this.name = name;
+        this.price = price;
+        this.stock = stock;
+        this.image_url = image_url;
+        this.detail_image_url = detail_image_url;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -27,9 +27,9 @@ public class Product {
     private Integer stock;
 
     @Column(nullable = true)
-    private String image_url;
-    private String detail_image_url;
-    private String nutrition_info_url;
+    private String imageUrl;
+    private String detailImageUrl;
+    private String nutritionInfoUrl;
     @ColumnDefault("0")
     private Integer discount;
 
@@ -37,12 +37,18 @@ public class Product {
     @ColumnDefault(value = "CURRENT_TIMESTAMP")
     private Date registered_at;
 
-    public Product(Category category, String name, int price, int stock, String image_url, String detail_image_url) {
+    public Product(Long id, Category category, String name, int price, int stock, String imageUrl, String detailImageUrl, String nutritionInfoUrl) {
+        this.id = id;
         this.category = category;
         this.name = name;
         this.price = price;
         this.stock = stock;
-        this.image_url = image_url;
-        this.detail_image_url = detail_image_url;
+        this.imageUrl = imageUrl;
+        this.detailImageUrl = detailImageUrl;
+        this.nutritionInfoUrl = nutritionInfoUrl;
+    }
+
+    public Product(Category category, String name, int price, int stock, String imageUrl, String detailImageUrl) {
+        this(null, category, name, price, stock, imageUrl, detailImageUrl, null);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -1,7 +1,8 @@
 package kkakka.mainservice.product.domain;
 
 import kkakka.mainservice.category.domain.Category;
-import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -10,19 +11,19 @@ import java.util.Date;
 
 @Entity
 @Table(name = "product")
-@Data
+@Getter
 @NoArgsConstructor
 public class Product {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "PRODUCT_ID")
     private Long productId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "CATEGORY_ID")
     private Category category;
 
-    @Column(nullable = false, length = 255)
+    @Column(nullable = false)
     private String name;
     private int price;
     private int stock;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -22,15 +22,15 @@ public class Product {
 
     @Column(nullable = false)
     private String name;
-    private int price;
-    private int stock;
+    private Integer price;
+    private Integer stock;
 
     @Column(nullable = true)
     private String image_url;
     private String detail_image_url;
     private String nutrition_info_url;
     @ColumnDefault("0")
-    private int discount;
+    private Integer discount;
 
     @Column(nullable = false, updatable = false, insertable = false)
     @ColumnDefault(value = "CURRENT_TIMESTAMP")

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -15,6 +15,7 @@ public class Product {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PRODUCT_ID")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -1,11 +1,9 @@
 package kkakka.mainservice.product.domain;
 
 import kkakka.mainservice.category.domain.Category;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-
 import javax.persistence.*;
 import java.util.Date;
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -15,8 +15,7 @@ public class Product {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "PRODUCT_ID")
-    private Long productId;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
@@ -4,5 +4,5 @@ import kkakka.mainservice.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    Product findByProductId(Long productId);
+//    Product findByPId(Long id);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
@@ -4,4 +4,5 @@ import kkakka.mainservice.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    Product findByProductId(Long productId);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
@@ -1,4 +1,7 @@
 package kkakka.mainservice.product.domain.repository;
 
-public interface ProductRepository {
+import kkakka.mainservice.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
@@ -4,5 +4,4 @@ import kkakka.mainservice.product.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-//    Product findByPId(Long id);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.annotation.PostConstruct;
 
 @RestController
-@RequestMapping("/product")
+@RequestMapping("/products")
 public class ProductController {
 
     private final ProductRepository productRepository;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -45,7 +45,7 @@ public class ProductController {
 
     @GetMapping("/{productId}")
     public ResponseEntity<ProductResponseDto> getProductDetail(@PathVariable("productId") Long productId) {
-        ProductResponseDto responseDto = productService.getProductByProductId(productId);
+        ProductResponseDto responseDto = productService.getProductDetail(productId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -58,12 +58,7 @@ public class ProductController {
     public ResponseEntity<List<ResponseCategoryProducts>> showCategoryProducts(@RequestParam("category") Long categoryId,
                                                                         Pageable pageable) {
         Page<ResponseCategoryProducts> result = categoryService.getProductsByCategoryId(categoryId, pageable);
-
-        System.out.println("전체 페이지 수: " + result.getTotalPages());
-        System.out.println("전체 상품목록 수: " + result.getTotalElements());
-        System.out.println("현재 페이지(기본0) : " + result.getNumber());
-        System.out.println("hasNext: " + result.hasNext());
-
+        
         return ResponseEntity.status(HttpStatus.OK).body(result.getContent());
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -19,10 +19,9 @@ import javax.annotation.PostConstruct;
 @RequestMapping("/product")
 public class ProductController {
 
-    ProductRepository productRepository;
-    ProductService productService;
+    private final ProductRepository productRepository;
+    private final ProductService productService;
 
-    @Autowired
     public ProductController(ProductRepository productRepository, ProductService productService) {
         this.productRepository = productRepository;
         this.productService = productService;
@@ -35,6 +34,7 @@ public class ProductController {
 
     @PostConstruct
     public void init() {
+
         Category category = new Category(1L, "비스킷/샌드");
         productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
         productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
@@ -44,7 +44,8 @@ public class ProductController {
     }
 
     @GetMapping("/{productId}")
-    public ResponseEntity<ProductResponseDto> getProductDetail(@PathVariable("productId") Long productId) {
+    public ResponseEntity<ProductResponseDto> showProductDetail(@PathVariable("productId") Long productId) {
+
         ProductResponseDto responseDto = productService.getProductDetail(productId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -1,19 +1,20 @@
 package kkakka.mainservice.product.ui;
 
+import kkakka.mainservice.category.application.CategoryService;
 import kkakka.mainservice.category.domain.Category;
+import kkakka.mainservice.category.ui.dto.ResponseCategoryProducts;
 import kkakka.mainservice.product.application.ProductService;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
 import kkakka.mainservice.product.ui.dto.ProductResponseDto;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.PostConstruct;
+import java.util.List;
 
 @RestController
 @RequestMapping("/products")
@@ -21,10 +22,13 @@ public class ProductController {
 
     private final ProductRepository productRepository;
     private final ProductService productService;
+    private final CategoryService categoryService;
 
-    public ProductController(ProductRepository productRepository, ProductService productService) {
+    public ProductController(ProductRepository productRepository, ProductService productService
+            , CategoryService categoryService) {
         this.productRepository = productRepository;
         this.productService = productService;
+        this.categoryService = categoryService;
     }
 
     @GetMapping("/health_check")
@@ -48,5 +52,18 @@ public class ProductController {
 
         ProductResponseDto responseDto = productService.getProductDetail(productId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @GetMapping("/products")
+    public ResponseEntity<List<ResponseCategoryProducts>> showCategoryProducts(@RequestParam("category") Long categoryId,
+                                                                        Pageable pageable) {
+        Page<ResponseCategoryProducts> result = categoryService.getProductsByCategoryId(categoryId, pageable);
+
+        System.out.println("전체 페이지 수: " + result.getTotalPages());
+        System.out.println("전체 상품목록 수: " + result.getTotalElements());
+        System.out.println("현재 페이지(기본0) : " + result.getNumber());
+        System.out.println("hasNext: " + result.hasNext());
+
+        return ResponseEntity.status(HttpStatus.OK).body(result.getContent());
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -1,10 +1,15 @@
 package kkakka.mainservice.product.ui;
 
 import kkakka.mainservice.category.domain.Category;
+import kkakka.mainservice.product.application.ProductService;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
+import kkakka.mainservice.product.ui.dto.ProductResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,10 +20,12 @@ import javax.annotation.PostConstruct;
 public class ProductController {
 
     ProductRepository productRepository;
+    ProductService productService;
 
     @Autowired
-    public ProductController(ProductRepository productRepository) {
+    public ProductController(ProductRepository productRepository, ProductService productService) {
         this.productRepository = productRepository;
+        this.productService = productService;
     }
 
     @GetMapping("/health_check")
@@ -28,11 +35,17 @@ public class ProductController {
 
     @PostConstruct
     public void init() {
-        Category category = new Category(1L,"비스킷/샌드");
-        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
-        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
-        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
-        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
-        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
+        Category category = new Category(1L, "비스킷/샌드");
+        productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
+        productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
+        productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
+        productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
+        productRepository.save(new Product(category, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10, "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png", "상세URL"));
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductResponseDto> getProductDetail(@PathVariable("productId") Long productId) {
+        ProductResponseDto responseDto = productService.getProductByProductId(productId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -1,5 +1,6 @@
 package kkakka.mainservice.product.ui;
 
+import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,5 +28,11 @@ public class ProductController {
 
     @PostConstruct
     public void init() {
+        Category category = new Category(1L,"비스킷/샌드");
+        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
+        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
+        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
+        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
+        productRepository.save(new Product(category,"롯데 제로 초콜릿칩 쿠키 168g",4480,10,"https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png","상세URL"));
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/ProductController.java
@@ -1,9 +1,31 @@
 package kkakka.mainservice.product.ui;
 
+import kkakka.mainservice.product.domain.Product;
+import kkakka.mainservice.product.domain.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.PostConstruct;
 
 @RestController
 @RequestMapping("/product")
 public class ProductController {
+
+    ProductRepository productRepository;
+
+    @Autowired
+    public ProductController(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    @GetMapping("/health_check")
+    public String status() {
+        return "It's Working in Product Service";
+    }
+
+    @PostConstruct
+    public void init() {
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
@@ -10,10 +10,10 @@ public class ProductResponseDto {
     private String name;
     private Integer price;
     private Integer stock;
-    private String image_url;
-    private String detail_image_url;
-    private String nutrition_info_url;
-    private int discount;
+    private String imageUrl;
+    private String detailImageUrl;
+    private String nutritionInfoUrl;
+    private int disCount;
 
     public void setCategoryName(String categoryName) {
         this.categoryName = categoryName;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
@@ -13,7 +13,7 @@ public class ProductResponseDto {
     private String imageUrl;
     private String detailImageUrl;
     private String nutritionInfoUrl;
-    private int disCount;
+    private int discount;
 
     public void setCategoryName(String categoryName) {
         this.categoryName = categoryName;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
@@ -1,6 +1,5 @@
 package kkakka.mainservice.product.ui.dto;
 
-import kkakka.mainservice.category.domain.Category;
 import lombok.Data;
 
 @Data

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
@@ -1,4 +1,22 @@
 package kkakka.mainservice.product.ui.dto;
 
+import kkakka.mainservice.category.domain.Category;
+import lombok.Data;
+
+@Data
 public class ProductResponseDto {
+
+    private Long productId;
+    private String categoryName;
+    private String name;
+    private int price;
+    private int stock;
+    private String image_url;
+    private String detail_image_url;
+    private String nutrition_info_url;
+    private int discount;
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Data;
 @Data
 public class ProductResponseDto {
 
-    private Long productId;
+    private Long id;
     private String categoryName;
     private String name;
     private Integer price;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponseDto.java
@@ -8,8 +8,8 @@ public class ProductResponseDto {
     private Long productId;
     private String categoryName;
     private String name;
-    private int price;
-    private int stock;
+    private Integer price;
+    private Integer stock;
     private String image_url;
     private String detail_image_url;
     private String nutrition_info_url;


### PR DESCRIPTION
## Resolve #6 

### 설명
- 카테고리별 페이징 상품 목록 조회 기능 과 상품 상세보기 API를 구현하였습니다.
- @PostConsructor 를 통해 더미 데이터를 넣어뒀습니다. ( 추후 삭제 요망 )
![image](https://user-images.githubusercontent.com/48666403/191895645-36889d03-69bc-428d-86f4-5ab2d3a71952.png)

- API uri
- category/{categoty_id}?page={number} ex) category/1?page=0
- product/{product_id}

- FE 개발자와 1페이지에 나타낼 Size 조정이 필요합니다.
![image](https://user-images.githubusercontent.com/48666403/191895792-79fae146-c205-4fe9-8296-513cc3ee18ab.png)
![image](https://user-images.githubusercontent.com/48666403/191895814-1bf6e28f-8e0e-493b-b67c-e9089e5a0729.png)


### 기타
- 정렬 기준등 상세 처리 필요
