### PR TITLE
fix: interceptor 가 제대로 동작하지 않는 문제

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/common/config/WebMvcConfig.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/config/WebMvcConfig.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -36,8 +37,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
-                .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/auth")
-                .excludePathPatterns("/api/login/token");
+                .addPathPatterns("/**")
+                .excludePathPatterns("/**/auth")
+                .excludePathPatterns("/**/login/token");
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -1,12 +1,16 @@
 package kkakka.mainservice.member.member.ui;
 
 import javax.annotation.PostConstruct;
+import kkakka.mainservice.member.auth.ui.AuthenticationPrincipal;
+import kkakka.mainservice.member.auth.ui.LoginMember;
 import kkakka.mainservice.member.member.domain.Member;
 import kkakka.mainservice.member.member.domain.MemberProviderName;
 import kkakka.mainservice.member.member.domain.Provider;
 import kkakka.mainservice.member.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,5 +37,10 @@ public class MemberController {
                         "20~29"
                 )
         );
+    }
+
+    @PostMapping("/me")
+    public ResponseEntity<Long> showMemberInfo(@AuthenticationPrincipal LoginMember loginMember) {
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestMember.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestMember.java
@@ -10,9 +10,9 @@ import kkakka.mainservice.member.auth.ui.Authority;
 
 public enum TestMember {
 
-    MEMBER_00("0000", "test.member.default", "0000", "member00",
+    MEMBER_00("0000", "1", "0000", "member00",
             "default@email.com", "00~00", "000-0000-0000", Authority.MEMBER),
-    MEMBER_01("0001", "test.member.01", "0001", "member01",
+    MEMBER_01("0001", "1", "0001", "member01",
             "test01@email.com", "20~29", "010-0000-0000", Authority.MEMBER);
 
     private String code;
@@ -54,7 +54,8 @@ public enum TestMember {
                 .orElse(MEMBER_00);
     }
 
-    public static boolean findByAccessToken(String accessToken) {
+    public static boolean isValidToken(String accessToken) {
+
         return FIXTURES.stream()
                 .anyMatch((member) -> member.accessToken.equals(accessToken));
     }

--- a/backend/main-service/src/test/java/kkakka/mainservice/member/acceptance/MemberAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/member/acceptance/MemberAcceptanceTest.java
@@ -1,0 +1,67 @@
+package kkakka.mainservice.member.acceptance;
+
+import static kkakka.mainservice.fixture.TestMember.MEMBER_01;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import kkakka.mainservice.DocumentConfiguration;
+import kkakka.mainservice.member.auth.ui.dto.SocialProviderCodeRequest;
+import kkakka.mainservice.member.member.domain.MemberProviderName;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class MemberAcceptanceTest extends DocumentConfiguration {
+
+    @DisplayName("사용자 검증이 필요한 요청 - 토큰 있음")
+    @Test
+    void showMemberInfo_success() {
+        // given
+        final String accessToken = 액세스_토큰_가져옴();
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .post("/api/members/me")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body()).isNotNull();
+    }
+
+    @DisplayName("사용자 검증이 필요한 요청 - 토큰 없음")
+    @Test
+    void showMemberInfo_fail() {
+        // given
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when()
+                .post("/api/members/me")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    private String 액세스_토큰_가져옴() {
+        final SocialProviderCodeRequest request = SocialProviderCodeRequest.create(
+                MEMBER_01.getCode(), MemberProviderName.TEST);
+
+        final ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post("/api/login/token")
+                .then().log().all().extract();
+
+        return response.body().jsonPath().get("accessToken");
+    }
+}


### PR DESCRIPTION
## Resolve #43 

### 설명
- `WebMvcConfig` 의 인터셉터 path pattern 이 제대로 동작하지 않는 문제가 있었습니다.
 ```java
    @Override
    public void addInterceptors(InterceptorRegistry registry) {
        registry.addInterceptor(loginInterceptor)
                .addPathPatterns("/**")
                .excludePathPatterns("/**/auth")
                .excludePathPatterns("/**/login/token");
    }
```

-  위와같이 수정하니 제대로 동작하는 것을 테스트(`MemberAcceptanceTest`)로 확인했습니다.
  base-url 을 cloud config 에서 가져오기 때문에 발생하는 문제가 아닌가 생각합니다.

- `MemberAcceptanceTest` 를 보시면, 
  - 회원 정보 조회 요청을 할 때 토큰이 없으면 401 에러를 반환하고
  - 토큰 요청(회원가입/로그인) 요청은 인터셉터를 거치지 않으며 이후 헤더에 토큰이 있는 요청은 200 을 받게 됩니다.
