### PR TITLE
feat: 회원 정보 조회 기능 구현

### DIFF
--- a/backend/main-service/src/docs/asciidoc/index.adoc
+++ b/backend/main-service/src/docs/asciidoc/index.adoc
@@ -21,6 +21,17 @@ include::{actual-snippets}/join-success/http-response.adoc[]
 
 
 == Member
+=== 회원 정보 조회
+
+- Request
+
+include::{actual-snippets}/member-info/http-request.adoc[]
+
+- Response
+
+include::{actual-snippets}/member-info/http-response.adoc[]
+
+
 === 회원 정보 수정
 ==== 이름 수정
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/auth/infrastructure/LoginInterceptor.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/auth/infrastructure/LoginInterceptor.java
@@ -19,7 +19,9 @@ public class LoginInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
             Object handler) {
-        if (request.getMethod().equals(HttpMethod.GET.name())) {
+        if (request.getMethod().equals(HttpMethod.GET.name())
+            && !request.getRequestURI().equals("/api/members/me")
+        ) {
             return true;
         }
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/application/MemberService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/application/MemberService.java
@@ -59,4 +59,9 @@ public class MemberService {
 
         memberRepository.save(member);
     }
+
+    public Member showInfo(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(NotFoundMemberException::new);
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/domain/Member.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/domain/Member.java
@@ -8,6 +8,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import kkakka.mainservice.member.member.ui.dto.MemberResponse;
 import kkakka.mainservice.member.member.util.MemberInfoPatterns;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -83,5 +84,9 @@ public class Member {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public MemberResponse toDto() {
+        return new MemberResponse(name, email, phone, address, ageGroup, grade);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -11,6 +11,7 @@ import kkakka.mainservice.member.member.domain.MemberProviderName;
 import kkakka.mainservice.member.member.domain.Provider;
 import kkakka.mainservice.member.member.domain.repository.MemberRepository;
 import kkakka.mainservice.member.member.ui.dto.MemberInfoRequest;
+import kkakka.mainservice.member.member.ui.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,9 +47,14 @@ public class MemberController {
         );
     }
 
-    @PostMapping("/me")
-    public ResponseEntity<Long> showMemberInfo(@AuthenticationPrincipal LoginMember loginMember) {
-        return ResponseEntity.ok().build();
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> showMemberInfo(@AuthenticationPrincipal LoginMember loginMember) {
+        if (loginMember.isAnonymous()) {
+            throw new AuthorizationException();
+        }
+
+        Member member = memberService.showInfo(loginMember.getId());
+        return ResponseEntity.ok(member.toDto());
     }
 
     @PatchMapping("/me")

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/dto/MemberResponse.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/dto/MemberResponse.java
@@ -1,4 +1,19 @@
 package kkakka.mainservice.member.member.ui.dto;
 
+import kkakka.mainservice.member.member.domain.Grade;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class MemberResponse {
+
+    private String name;
+    private String email;
+    private String phone;
+    private String address;
+    private String ageGroup;
+    private Grade grade;
 }


### PR DESCRIPTION
## Resolve #56 

### 설명
- 토큰에 담긴 회원 아이디로 정보를 조회하는 API 를 구현했습니다.
- 회원 정보 수정 인수테스트를 이어서 작성했습니다.
- API 문서를 추가했습니다.
  ![스크린샷 2022-10-05 오후 12 18 53](https://user-images.githubusercontent.com/52682603/193974087-d32feb88-e10e-4197-82e7-8f46ff763be1.png)

### 기타
- 이후 쿠폰함, 주문내역 등 API 를 어떻게 표현할지 논의가 필요합니다.
