### PR TITLE
feat: 회원 인증 공통 로직 분리

### DIFF
--- a/backend/main-service/src/docs/asciidoc/index.adoc
+++ b/backend/main-service/src/docs/asciidoc/index.adoc
@@ -21,6 +21,17 @@ include::{actual-snippets}/join-success/http-response.adoc[]
 
 
 == Member
+=== 회원 정보 조회
+
+- Request
+
+include::{actual-snippets}/member-info/http-request.adoc[]
+
+- Response
+
+include::{actual-snippets}/member-info/http-response.adoc[]
+
+
 === 회원 정보 수정
 ==== 이름 수정
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/auth/infrastructure/LoginInterceptor.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/auth/infrastructure/LoginInterceptor.java
@@ -19,7 +19,9 @@ public class LoginInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
             Object handler) {
-        if (request.getMethod().equals(HttpMethod.GET.name())) {
+        if (request.getMethod().equals(HttpMethod.GET.name())
+            && !request.getRequestURI().equals("/api/members/me")
+        ) {
             return true;
         }
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/auth/infrastructure/LoginInterceptor.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/auth/infrastructure/LoginInterceptor.java
@@ -19,9 +19,7 @@ public class LoginInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
             Object handler) {
-        if (request.getMethod().equals(HttpMethod.GET.name())
-            && !request.getRequestURI().equals("/api/members/me")
-        ) {
+        if (request.getMethod().equals(HttpMethod.GET.name())) {
             return true;
         }
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/auth/ui/MemberOnly.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/auth/ui/MemberOnly.java
@@ -1,0 +1,12 @@
+package kkakka.mainservice.member.auth.ui;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberOnly {
+
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/auth/util/LoginAop.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/auth/util/LoginAop.java
@@ -1,0 +1,27 @@
+package kkakka.mainservice.member.auth.util;
+
+import java.util.Arrays;
+import kkakka.mainservice.member.auth.exception.AuthorizationException;
+import kkakka.mainservice.member.auth.ui.LoginMember;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class LoginAop {
+
+    @Before("@annotation(kkakka.mainservice.member.auth.ui.MemberOnly) "
+            + "|| @within(kkakka.mainservice.member.auth.ui.MemberOnly)")
+    public void checkLoginMember(JoinPoint joinPoint) {
+        final LoginMember loginMember = (LoginMember) Arrays.stream(joinPoint.getArgs())
+                .filter(argument -> argument instanceof LoginMember)
+                .findAny()
+                .orElseThrow(AuthorizationException::new);
+
+        if (loginMember.isAnonymous()) {
+            throw new AuthorizationException();
+        }
+    }
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/application/MemberService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/application/MemberService.java
@@ -59,4 +59,9 @@ public class MemberService {
 
         memberRepository.save(member);
     }
+
+    public Member showInfo(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(NotFoundMemberException::new);
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/domain/Member.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/domain/Member.java
@@ -8,6 +8,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import kkakka.mainservice.member.member.ui.dto.MemberResponse;
 import kkakka.mainservice.member.member.util.MemberInfoPatterns;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -83,5 +84,9 @@ public class Member {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public MemberResponse toDto() {
+        return new MemberResponse(name, email, phone, address, ageGroup, grade);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -11,6 +11,7 @@ import kkakka.mainservice.member.member.domain.MemberProviderName;
 import kkakka.mainservice.member.member.domain.Provider;
 import kkakka.mainservice.member.member.domain.repository.MemberRepository;
 import kkakka.mainservice.member.member.ui.dto.MemberInfoRequest;
+import kkakka.mainservice.member.member.ui.dto.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,9 +47,14 @@ public class MemberController {
         );
     }
 
-    @PostMapping("/me")
-    public ResponseEntity<Long> showMemberInfo(@AuthenticationPrincipal LoginMember loginMember) {
-        return ResponseEntity.ok().build();
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> showMemberInfo(@AuthenticationPrincipal LoginMember loginMember) {
+        if (loginMember.isAnonymous()) {
+            throw new AuthorizationException();
+        }
+
+        Member member = memberService.showInfo(loginMember.getId());
+        return ResponseEntity.ok(member.toDto());
     }
 
     @PatchMapping("/me")

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -1,9 +1,9 @@
 package kkakka.mainservice.member.member.ui;
 
 import javax.annotation.PostConstruct;
-import kkakka.mainservice.member.auth.exception.AuthorizationException;
 import kkakka.mainservice.member.auth.ui.AuthenticationPrincipal;
 import kkakka.mainservice.member.auth.ui.LoginMember;
+import kkakka.mainservice.member.auth.ui.MemberOnly;
 import kkakka.mainservice.member.member.application.MemberService;
 import kkakka.mainservice.member.member.application.dto.MemberUpdateDto;
 import kkakka.mainservice.member.member.domain.Member;
@@ -16,11 +16,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@MemberOnly
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
@@ -48,11 +48,8 @@ public class MemberController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MemberResponse> showMemberInfo(@AuthenticationPrincipal LoginMember loginMember) {
-        if (loginMember.isAnonymous()) {
-            throw new AuthorizationException();
-        }
-
+    public ResponseEntity<MemberResponse> showMemberInfo(
+            @AuthenticationPrincipal LoginMember loginMember) {
         Member member = memberService.showInfo(loginMember.getId());
         return ResponseEntity.ok(member.toDto());
     }
@@ -62,10 +59,6 @@ public class MemberController {
             @AuthenticationPrincipal LoginMember loginMember,
             @RequestBody MemberInfoRequest memberInfoRequest
     ) {
-        if (loginMember.isAnonymous()) {
-            throw new AuthorizationException();
-        }
-
         memberService.updateMember(MemberUpdateDto.create(loginMember.getId(), memberInfoRequest));
         return ResponseEntity.ok().build();
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/dto/MemberResponse.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/dto/MemberResponse.java
@@ -1,4 +1,19 @@
 package kkakka.mainservice.member.member.ui.dto;
 
+import kkakka.mainservice.member.member.domain.Grade;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class MemberResponse {
+
+    private String name;
+    private String email;
+    private String phone;
+    private String address;
+    private String ageGroup;
+    private Grade grade;
 }


### PR DESCRIPTION
## Resolve #59 

### 설명
- `LoginMember` 에서 `MEMBER`, `ANONYMOUS` 판단하는 부분이 반복될 것으로 예상되어 AOP로 분리했습니다.
- `@MemberOnly` 어노테이션을 클래스 혹은 메서드에 붙여서 사용합니다.
- 비회원(=`ANONYMOUS`)일 때 예외를 발생시킵니다.
- 인터셉터를 통과하고 검증하기 때문에 효율은 떨어질 수 있으나 간단하게 구현할 수 있습니다.
