### PR TITLE
fix: jar 환경의 구동에서 resource 읽어오기 수정

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/DataLoadRunner.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/DataLoadRunner.java
@@ -1,10 +1,5 @@
 package kkakka.mainservice;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +7,10 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 @Profile({"local", "dev"})
@@ -21,26 +20,26 @@ public class DataLoadRunner implements CommandLineRunner {
     private final DataLoader dataLoader;
 
     @Override
-    public void run(String... args) {
+    public void run(String... args) throws IOException {
         final Logger logger = LoggerFactory.getLogger(DataLoadRunner.class);
         String line;
         String CSV_DELIMITER = ",";
 
         List<String[]> rows = new ArrayList<>();
 
-        try (
-                final FileInputStream fileInputStream = new FileInputStream(
-                        new ClassPathResource("/static/product-data.csv").getFile());
-                final BufferedReader bufferedReader = new BufferedReader(
-                        new InputStreamReader(fileInputStream))
-        ) {
+        ClassPathResource classPathResource = new ClassPathResource("/static/product-data.csv");
+        if (classPathResource.exists() == false) {
+            throw new IllegalArgumentException();
+        }
+        try (InputStream is = new BufferedInputStream(classPathResource.getInputStream())) {
+
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             while ((line = bufferedReader.readLine()) != null) {
                 final String[] row = line.split(CSV_DELIMITER);
                 rows.add(row);
             }
 
             dataLoader.saveData(rows);
-
         } catch (Exception e) {
             logger.error("===============================");
             logger.error("데이터 로드 중 에러 발생");


### PR DESCRIPTION
## Resolve #88 

### 설명
- jar파일로 구동할 시 resoruce를 제대로 참조하지 못하는 문제를 해결하였습니다.
- 코드를 많이 바꿨는데 마음대로 수정해도 됩니당 
- jar로 실행할 때는 getfile() 이 아니라 스트림으로 읽어서 스트림으로 처리해야 된다고 합니다 왜인지는 저도 잘 모르겠습니다 ~! 