### PR TITLE
fix: ProductOrder 엔티티의 'count'를 'quantity'로 수정

### DIFF
--- a/backend/main-service/src/main/resources/db/migration/V2210191147_change_product_order_quantity.sql
+++ b/backend/main-service/src/main/resources/db/migration/V2210191147_change_product_order_quantity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE product_order CHANGE `count` quantity int;


### PR DESCRIPTION
### 설명
- `ProductOrder` 의 주문 수량 필드를 `count` -> `quantity` 로 변경한 것을 DB에 반영
