### PR TITLE
fix: gradle 의존성 옵션 변경, restdocs 문서 설정 변경, static resource 읽도록 mvc 설정 수정

### DIFF
--- a/backend/main-service/build.gradle
+++ b/backend/main-service/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     runtimeOnly 'mysql:mysql-connector-java'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.flywaydb:flyway-core'
-    compileOnly 'org.flywaydb:flyway-mysql'
+    implementation 'org.flywaydb:flyway-mysql'
 
     /* lombok */
     compileOnly 'org.projectlombok:lombok'
@@ -101,9 +101,8 @@ asciidoctor {
 task createDocument(type: Copy) {
     dependsOn asciidoctor
     asciidoctor
-    delete file('src/main/resources/static/index.html')
-    from file("build/docs/asciidoc/index.html")
-    into file("src/main/resources/static")
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
 }
 
 build {

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/LogAop.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/LogAop.java
@@ -20,11 +20,11 @@ public class LogAop {
 
     @AfterThrowing(value = "execution(* kkakka.mainservice..*(..))", throwing = "e")
     public void checkException(JoinPoint joinPoint, Exception e) {
-        log.warn("예외 발생지점 : {}", joinPoint.getSignature().toString());
-        log.warn("------- StackTrace Start -------");
+        log.error("예외 발생지점 : {}", joinPoint.getSignature().toString());
+        log.error("------- StackTrace Start -------");
         for (StackTraceElement element : e.getStackTrace()) {
-            log.warn("{}", element);
+            log.error("{}", element);
         }
-        log.warn("------- StackTrace End -------");
+        log.error("------- StackTrace End -------");
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/config/WebMvcConfig.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/config/WebMvcConfig.java
@@ -9,11 +9,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private static final String[] CLASSPATH_RESOURCE_LOCATIONS = {
+            "classpath:/META-INF/resources/", "classpath:/resources/",
+            "classpath:/static/", "classpath:/public/"};
 
     private final JwtTokenProvider jwtTokenProvider;
     private final LoginInterceptor loginInterceptor;
@@ -32,7 +37,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public AuthenticationPrincipalArgumentResolver createAuthenticationPrincipalArgumentResolver() {
         return new AuthenticationPrincipalArgumentResolver(jwtTokenProvider);
     }
-    
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
@@ -40,5 +45,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/**/auth")
                 .excludePathPatterns("/**/login/token")
                 .excludePathPatterns("/**/coupons/**");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations(CLASSPATH_RESOURCE_LOCATIONS);
     }
 }

--- a/backend/main-service/src/main/resources/bootstrap.yml
+++ b/backend/main-service/src/main/resources/bootstrap.yml
@@ -6,9 +6,9 @@ spring:
   profiles:
     active: local
     group:
-      "local": "console-logging"
-      "dev": "console-logging, file-logging, performance-logging"
-      "prod": "file-logging"
+      "local": "console-logging, error-file-logging"
+      "dev": "console-logging, file-logging, performance-logging, error-file-logging"
+      "prod": "file-logging, error-file-logging"
 
 logging:
   config: classpath:logback-spring.xml

--- a/backend/main-service/src/main/resources/logback-spring.xml
+++ b/backend/main-service/src/main/resources/logback-spring.xml
@@ -5,14 +5,14 @@
   <!-- log file name -->
   <property name="LOG_FILE_NAME" value="kka-kka"/>
   <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-
   <property name="LOG_FILE_PATTERN"
     value="%d{HH:mm:ss.SSS} [%thread] [%-5level] [%logger{0}] - %m%n"/>
+  <property name="LOG_PATTERN"
+    value="%white(%d{HH:mm:ss.SSS}) %cyan([%thread]) %highlight([%-5level]) %yellow([%logger{0}]) - %boldWhite(%m%n)"/>
 
   <springProfile name="console-logging">
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
       <layout class="ch.qos.logback.classic.PatternLayout">
-        <!-- default pattern -->
         <pattern>${CONSOLE_LOG_PATTERN}</pattern>
       </layout>
     </appender>
@@ -30,7 +30,7 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
       <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-        <pattern>%msg%n</pattern>
+        <pattern>${LOG_PATTERN}</pattern>
       </encoder>
       <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
         <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.zip</fileNamePattern>
@@ -51,7 +51,7 @@
     </appender>
   </springProfile>
 
-  <springProfile name="dev">
+  <springProfile name="error-file-logging">
     <appender name="file-error-logger" class="ch.qos.logback.core.rolling.RollingFileAppender">
       <file>${LOG_PATH}/error.log</file>
       <filter class="ch.qos.logback.classic.filter.LevelFilter">
@@ -69,7 +69,7 @@
       <encoder>
         <charset>utf8</charset>
         <Pattern>
-          %d{yyyy-MM-dd HH:mm:ss}:%-4relative %-5level [%C.%M]:%L] %n    > %msg%n
+          ${LOG_PATTERN}
         </Pattern>
       </encoder>
     </appender>


### PR DESCRIPTION
## Resolve #32 

### 설명
- API 문서를 실행중인 서버에서 조회할 수 없던 문제를 해결했습니다.
- 문서 설정을 변경함에 따라 변동된 `createDocument` 설정을 변경했습니다.
- Flyway 관련 의존성이 `compileOnly` 로 설정되어 jar 파일을 제대로 구동하지 못하던 문제를 해결했습니다.
