### PR TITLE
fix: flyway 쿼리 및 버전 변경

### DIFF
--- a/backend/main-service/src/main/resources/db/migration/V2210191838__add_product_nutrition.sql
+++ b/backend/main-service/src/main/resources/db/migration/V2210191838__add_product_nutrition.sql
@@ -1,2 +1,4 @@
+ALTER TABLE product ADD COLUMN nutrition_id BIGINT;
+
 ALTER TABLE product
     ADD CONSTRAINT FK_PRODUCT_ON_NUTRITION FOREIGN KEY (nutrition_id) REFERENCES nutrition (id);


### PR DESCRIPTION
## Resolve #118 

### 설명
- 마이그레이션 파일 중 `Product` 에 `nutrition_id` 저장하는 부분이 누락되어 생기는 오류를 해결했습니다.
- `Nutrition` 테이블 생성과 `Product` 버전이 같아 오류가 발생할 것으로 예상되어 수정했습니다.