### PR TITLE
fix: review 조회에 productId 고정값에서 실제 id로 변경

### DIFF
--- a/frontend/pages/product/productDetail/index.js
+++ b/frontend/pages/product/productDetail/index.js
@@ -74,7 +74,7 @@ export default function productDetail() {
 
   const getReview = async () => {
     if (productId) {
-      await axios.get(`/api/reviews?product=703`).then((res) => {
+      await axios.get(`/api/reviews?product=${productId}`).then((res) => {
         setReviews(res.data);
       });
     }


### PR DESCRIPTION
### 설명
- 상품에 달린 후기 조회 API 에 `productId` 값이 고정으로 할당되어 생기는 오류를 해결했습니다.
