### PR TITLE
refactor: 더보기 방식 페이징에 마지막인지 표시하는 기능 추가

### DIFF
--- a/backend/main-service/src/docs/asciidoc/auth_member.adoc
+++ b/backend/main-service/src/docs/asciidoc/auth_member.adoc
@@ -67,3 +67,14 @@ include::{snippets}/orders-info-member-success/http-request.adoc[]
 - Response
 
 include::{snippets}/orders-info-member-success/http-response.adoc[]
+
+
+==== 회원 주문내역 조회 (페이지가 더 있을 때)
+
+- Request
+
+include::{snippets}/orders-info-member-not-last-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/orders-info-member-not-last-success/http-response.adoc[]

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/dto/NoOffsetPageInfo.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/dto/NoOffsetPageInfo.java
@@ -10,11 +10,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NoOffsetPageInfo {
 
+    private long lastId;
     private boolean isLastPage;
     private int pageSize;
     private int curSize;
 
-    public static NoOffsetPageInfo from(boolean isLastPage, int pageSize, int curSize) {
-        return new NoOffsetPageInfo(isLastPage, pageSize, curSize);
+    public static NoOffsetPageInfo from(long lastId, boolean isLastPage, int pageSize, int curSize) {
+        return new NoOffsetPageInfo(lastId, isLastPage, pageSize, curSize);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/dto/NoOffsetPageInfo.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/dto/NoOffsetPageInfo.java
@@ -1,0 +1,20 @@
+package kkakka.mainservice.common.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class NoOffsetPageInfo {
+
+    private boolean isLastPage;
+    private int pageSize;
+    private int curSize;
+
+    public static NoOffsetPageInfo from(boolean isLastPage, int pageSize, int curSize) {
+        return new NoOffsetPageInfo(isLastPage, pageSize, curSize);
+    }
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/dto/PageableNoOffsetResponse.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/dto/PageableNoOffsetResponse.java
@@ -1,0 +1,22 @@
+package kkakka.mainservice.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageableNoOffsetResponse<T> {
+
+    @JsonProperty(value = "data")
+    private T responseDto;
+    @JsonProperty(value = "pageInfo")
+    private NoOffsetPageInfo pageInfo;
+
+    public static <T> PageableNoOffsetResponse<T> from(T responseDto, NoOffsetPageInfo pageInfo) {
+        return new PageableNoOffsetResponse<>(responseDto, pageInfo);
+    }
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -64,13 +64,19 @@ public class MemberController {
         final List<MemberOrderDto> memberOrderDtos = orderService.showMemberOrders(
                 loginMember.getId(),
                 orderId, pageSize);
+        final Long lastOrderIdInList = memberOrderDtos.get(memberOrderDtos.size() - 1).getId();
+
         final boolean isLastOrder = orderService.checkIsLastOrder(
                 loginMember.getId(),
-                memberOrderDtos.get(memberOrderDtos.size() - 1).getId()
+                lastOrderIdInList
         );
 
-        final NoOffsetPageInfo pageInfo = NoOffsetPageInfo.from(isLastOrder, pageSize,
-                memberOrderDtos.size());
+        final NoOffsetPageInfo pageInfo = NoOffsetPageInfo.from(
+                lastOrderIdInList,
+                isLastOrder,
+                pageSize,
+                memberOrderDtos.size()
+        );
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 PageableNoOffsetResponse.from(

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -2,6 +2,8 @@ package kkakka.mainservice.member.member.ui;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import kkakka.mainservice.common.dto.NoOffsetPageInfo;
+import kkakka.mainservice.common.dto.PageableNoOffsetResponse;
 import kkakka.mainservice.member.auth.ui.AuthenticationPrincipal;
 import kkakka.mainservice.member.auth.ui.LoginMember;
 import kkakka.mainservice.member.auth.ui.MemberOnly;
@@ -54,7 +56,7 @@ public class MemberController {
     }
 
     @GetMapping("/me/orders")
-    public ResponseEntity<List<OrderResponse>> findOrders(
+    public ResponseEntity<PageableNoOffsetResponse<List<OrderResponse>>> findOrders(
             @AuthenticationPrincipal LoginMember loginMember,
             @RequestParam(required = false) Long orderId,
             @RequestParam(defaultValue = "6") int pageSize
@@ -62,10 +64,19 @@ public class MemberController {
         final List<MemberOrderDto> memberOrderDtos = orderService.showMemberOrders(
                 loginMember.getId(),
                 orderId, pageSize);
+        final boolean isLastOrder = orderService.checkIsLastOrder(
+                loginMember.getId(),
+                memberOrderDtos.get(memberOrderDtos.size() - 1).getId()
+        );
+
+        final NoOffsetPageInfo pageInfo = NoOffsetPageInfo.from(isLastOrder, pageSize,
+                memberOrderDtos.size());
+
         return ResponseEntity.status(HttpStatus.OK).body(
-                memberOrderDtos.stream()
-                        .map(MemberOrderDto::toResponseDto)
-                        .collect(Collectors.toList())
+                PageableNoOffsetResponse.from(
+                        memberOrderDtos.stream()
+                                .map(MemberOrderDto::toResponseDto)
+                                .collect(Collectors.toList()), pageInfo)
         );
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
@@ -1,5 +1,9 @@
 package kkakka.mainservice.order.application;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import kkakka.mainservice.common.exception.KkaKkaException;
 import kkakka.mainservice.common.exception.NotOrderOwnerException;
 import kkakka.mainservice.member.auth.ui.LoginMember;
@@ -22,10 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -71,6 +71,10 @@ public class OrderService {
         final List<Order> orders = orderRepositorySupport.findByMemberId(memberId, orderId,
                 pageSize);
 
+        if (orders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         List<MemberOrderDto> dtos = new ArrayList<>();
         for (Order order : orders) {
             List<ProductOrder> productOrders = order.getProductOrders();
@@ -83,6 +87,11 @@ public class OrderService {
             );
         }
         return dtos;
+    }
+
+    public boolean checkIsLastOrder(Long memberId, Long orderId) {
+        final List<Order> orders = orderRepositorySupport.isLastId(memberId, orderId);
+        return orders.isEmpty();
     }
 
     @Transactional

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepositorySupport.java
@@ -1,6 +1,6 @@
 package kkakka.mainservice.order.domain.repository;
 
-import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import kkakka.mainservice.order.domain.Order;
@@ -21,11 +21,6 @@ public class OrderRepositorySupport extends QuerydslRepositorySupport {
     }
 
     public List<Order> findByMemberId(Long memberId, Long lastId, int pageSize) {
-        BooleanBuilder dynamicLtId = new BooleanBuilder();
-        if (lastId != null) {
-            dynamicLtId.and(QOrder.order.id.lt(lastId));
-        }
-
         return jpaQueryFactory
                 .selectFrom(QOrder.order)
                 .leftJoin(QOrder.order.productOrders, QProductOrder.productOrder)
@@ -33,9 +28,18 @@ public class OrderRepositorySupport extends QuerydslRepositorySupport {
                 .leftJoin(QProductOrder.productOrder.product, QProduct.product)
                 .fetchJoin()
                 .where(QOrder.order.member.id.eq(memberId))
-                .where(dynamicLtId)
+                .where(
+                        ltOrderLastId(lastId)
+                )
                 .orderBy(QOrder.order.id.desc())
                 .limit(pageSize)
                 .fetch();
+    }
+
+    private BooleanExpression ltOrderLastId(Long lastId) {
+        if (lastId == null) {
+            return null;
+        }
+        return QOrder.order.id.lt(lastId);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepositorySupport.java
@@ -42,4 +42,14 @@ public class OrderRepositorySupport extends QuerydslRepositorySupport {
         }
         return QOrder.order.id.lt(lastId);
     }
+
+    public List<Order> isLastId(Long memberId, Long lastId) {
+        return jpaQueryFactory
+                .selectFrom(QOrder.order)
+                .where(QOrder.order.member.id.eq(memberId))
+                .where(QOrder.order.id.lt(lastId))
+                .orderBy(QOrder.order.id.desc())
+                .limit(1)
+                .fetch();
+    }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/order/acceptance/OrderAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/order/acceptance/OrderAcceptanceTest.java
@@ -19,6 +19,7 @@ import javax.persistence.PersistenceContext;
 import kkakka.mainservice.DocumentConfiguration;
 import kkakka.mainservice.member.auth.ui.dto.SocialProviderCodeRequest;
 import kkakka.mainservice.member.member.domain.MemberProviderName;
+import kkakka.mainservice.member.member.ui.dto.OrderResponse;
 import kkakka.mainservice.order.application.dto.ProductOrderDto;
 import kkakka.mainservice.order.ui.dto.OrderRequest;
 import kkakka.mainservice.review.ui.dto.ReviewRequest;
@@ -85,8 +86,7 @@ public class OrderAcceptanceTest extends DocumentConfiguration {
         //given
         String accessToken = 액세스_토큰_가져옴();
         주문_요청함(accessToken, PRODUCT_1.getId());
-        후기_작성함(accessToken, "test-review", 5.0, PRODUCT_1.getId());
-
+        후기_작성함(accessToken, "test-review", 5.0);
         주문_요청함(accessToken, PRODUCT_2.getId());
 
         //when
@@ -102,10 +102,10 @@ public class OrderAcceptanceTest extends DocumentConfiguration {
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.body().as(List.class)).hasSize(2);
+        assertThat(response.jsonPath().getList("data")).hasSize(2);
     }
 
-    private void 후기_작성함(String accessToken, String contents, Double rating, Long productId) {
+    private void 후기_작성함(String accessToken, String contents, Double rating) {
         final ReviewRequest reviewRequest = new ReviewRequest(contents, rating);
         final ExtractableResponse<Response> orderResponse = RestAssured
                 .given().log().all()
@@ -115,7 +115,7 @@ public class OrderAcceptanceTest extends DocumentConfiguration {
                 .get("/api/members/me/orders")
                 .then().log().all()
                 .extract();
-        final String productOrderId = orderResponse.body().path("[0].productOrders[0].id")
+        final String productOrderId = orderResponse.body().path("data[0].productOrders[0].id")
                 .toString();
 
         RestAssured.given().log().all()


### PR DESCRIPTION
## Resolve #152 

### 설명
- 더보기 방식 페이징(현재는 회원 주문내역 조회에서 사용) API가 마지막 페이지인지 아닌지를 판단할 수 없어 리팩토링했습니다.
- 한 번 주문내역을 조회한 뒤, 값이 더 있는지 한 번 더 쿼리를 실행해서 확인합니다.
- API가 아래와 같이 변경됩니다.

  ```json
   {
    "data" : [ {
      "id" : 4,
      "orderedAt" : "2022-10-25 17:39:07",
      "totalPrice" : 4480,
      "productOrders" : [ {
        "id" : 9,
        "price" : 4480,
        "quantity" : 1,
        "deleted" : 0,
        "product" : {
          "id" : 2,
          "name" : "롯데 마가렛트 오리지널 176g",
          "price" : 4480,
          "imageUrl" : "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
          "discount" : 0
        },
        "review" : null
      } ]
    }, {
      "id" : 3,
      "orderedAt" : "2022-10-25 17:39:06",
      "totalPrice" : 4480,
      "productOrders" : [ {
        "id" : 8,
        "price" : 4480,
        "quantity" : 1,
        "deleted" : 0,
        "product" : {
          "id" : 1,
          "name" : "롯데 제로 초콜릿칩 쿠키 168g",
          "price" : 4480,
          "imageUrl" : "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
          "discount" : 0
        },
        "review" : {
          "id" : 1,
          "contents" : "test-review",
          "rating" : 5.0,
          "createdAt" : "2022-10-25 17:39:07"
        }
      } ]
    } ],
    "pageInfo" : {
      "lastId" : 3,
      "pageSize" : 6,
      "curSize" : 2,
      "lastPage" : true
    }
  }
```

- `lastId` 값을 FE에서 직접 확인하지 않아도 되도록 응답값에 추가했습니다.
- `NoOffsetPageInfo`, `PageableNoOffsetResponse`로 `common/dto` 에 추가해두어 다른 로직에도 사용할 수 있게 했습니다.