### PR TITLE
refactor: 회원의 총 주문 수를 보여주는 API 구현

### DIFF
--- a/backend/main-service/src/docs/asciidoc/auth_member.adoc
+++ b/backend/main-service/src/docs/asciidoc/auth_member.adoc
@@ -78,3 +78,14 @@ include::{snippets}/orders-info-member-not-last-success/http-request.adoc[]
 - Response
 
 include::{snippets}/orders-info-member-not-last-success/http-response.adoc[]
+
+
+=== 회원 총 주문 수 조회
+
+- Request
+
+include::{snippets}/orders-info-member-count-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/orders-info-member-count-success/http-response.adoc[]

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/exception/IllegalQuantityException.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/exception/IllegalQuantityException.java
@@ -1,0 +1,5 @@
+package kkakka.mainservice.common.exception;
+
+public class IllegalQuantityException extends KkaKkaException {
+
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -1,6 +1,8 @@
 package kkakka.mainservice.member.member.ui;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import kkakka.mainservice.common.dto.NoOffsetPageInfo;
 import kkakka.mainservice.common.dto.PageableNoOffsetResponse;
@@ -56,7 +58,7 @@ public class MemberController {
     }
 
     @GetMapping("/me/orders")
-    public ResponseEntity<PageableNoOffsetResponse<List<OrderResponse>>> findOrders(
+    public ResponseEntity<PageableNoOffsetResponse<List<OrderResponse>>> showMyOrders(
             @AuthenticationPrincipal LoginMember loginMember,
             @RequestParam(required = false) Long orderId,
             @RequestParam(defaultValue = "6") int pageSize
@@ -84,5 +86,13 @@ public class MemberController {
                                 .map(MemberOrderDto::toResponseDto)
                                 .collect(Collectors.toList()), pageInfo)
         );
+    }
+
+    @GetMapping("/me/orders/all")
+    public ResponseEntity<Map<String, Integer>> showOrderCount(@AuthenticationPrincipal LoginMember loginMember) {
+        final int orderCount = orderService.showMemberOrderCount(loginMember.getId());
+        final Map<String, Integer> result = new HashMap<>();
+        result.put("orderCount", orderCount);
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import kkakka.mainservice.common.exception.KkaKkaException;
+import kkakka.mainservice.common.exception.NotFoundMemberException;
 import kkakka.mainservice.common.exception.NotOrderOwnerException;
 import kkakka.mainservice.member.auth.ui.LoginMember;
 import kkakka.mainservice.member.member.domain.Member;
@@ -106,6 +107,12 @@ public class OrderService {
                 productOrderRepository.save(productOrder);
             }
         });
+    }
+
+    public int showMemberOrderCount(Long id) {
+        final Member member = memberRepository.findById(id)
+                .orElseThrow(NotFoundMemberException::new);
+        return orderRepository.countAllByMemberId(member.getId());
     }
 
     @NotNull

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
@@ -45,7 +45,8 @@ public class OrderService {
     public Long order(OrderDto orderDto) {
         Long memberId = orderDto.getMemberId();
         List<ProductOrderDto> productOrderDtos = orderDto.getProductOrders();
-        Member member = memberRepository.findById(memberId).orElseThrow();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
         Recipient recipient = Recipient.from(orderDto.getRecipientDto());
 
         List<ProductOrder> productOrders = new ArrayList<>();

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/ProductOrder.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/ProductOrder.java
@@ -1,13 +1,20 @@
 package kkakka.mainservice.order.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import kkakka.mainservice.common.exception.IllegalQuantityException;
 import kkakka.mainservice.common.exception.OutOfStockException;
 import kkakka.mainservice.product.domain.Product;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Entity
 @Table(name = "product_order")
@@ -36,6 +43,10 @@ public class ProductOrder {
 
     public static ProductOrder create(Product product, int price, int quantity) {
         ProductOrder productOrder = new ProductOrder(null, null, product, price, quantity, 0);
+
+        if (quantity < 1) {
+            throw new IllegalQuantityException();
+        }
 
         if (product.inStock(quantity)) {
             product.reduceStock(quantity);

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
+    int countAllByMemberId(Long memberId);
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestDataLoader.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestDataLoader.java
@@ -92,19 +92,19 @@ public class TestDataLoader implements CommandLineRunner {
                 new Nutrition("270", "36", "15", "2.2", "13", "7", "0.5", "0", "150", "0")
         );
 
-        PRODUCT_1 = productRepository.save(new Product(CATEGORY_1, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 10,
+        PRODUCT_1 = productRepository.save(new Product(CATEGORY_1, "롯데 제로 초콜릿칩 쿠키 168g", 4480, 100,
                 "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
                 "상세URL", NUTRITION_1));
-        PRODUCT_2 = productRepository.save(new Product(CATEGORY_1, "롯데 마가렛트 오리지널 176g", 4480, 10,
+        PRODUCT_2 = productRepository.save(new Product(CATEGORY_1, "롯데 마가렛트 오리지널 176g", 4480, 100,
                 "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
                 "상세URL", NUTRITION_2));
-        PRODUCT_3 = productRepository.save(new Product(CATEGORY_1, "롯데 웨하스 바닐라맛 50g", 4480, 10,
+        PRODUCT_3 = productRepository.save(new Product(CATEGORY_1, "롯데 웨하스 바닐라맛 50g", 4480, 100,
                 "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
                 "상세URL", NUTRITION_3));
-        PRODUCT_4 = productRepository.save(new Product(CATEGORY_2, "롯데 웨하스 딸기맛 50g", 4480, 10,
+        PRODUCT_4 = productRepository.save(new Product(CATEGORY_2, "롯데 웨하스 딸기맛 50g", 4480, 100,
                 "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
                 "상세URL", NUTRITION_4));
-        PRODUCT_5 = productRepository.save(new Product(CATEGORY_2, "롯데 롯샌 파인애플 105g", 4480, 10,
+        PRODUCT_5 = productRepository.save(new Product(CATEGORY_2, "롯데 롯샌 파인애플 105g", 4480, 100,
                 "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
                 "상세URL", NUTRITION_5));
 

--- a/backend/main-service/src/test/java/kkakka/mainservice/order/application/OrderServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/order/application/OrderServiceTest.java
@@ -113,7 +113,7 @@ class OrderServiceTest extends TestContext {
     @DisplayName("상품주문 - 실패(재고수량초과)")
     public void productOrder_fail_inventoryExceeded() {
         //given
-        ProductOrderDto productOrderDto1 = new ProductOrderDto(PRODUCT_1.getId(), 11);
+        ProductOrderDto productOrderDto1 = new ProductOrderDto(PRODUCT_1.getId(), Integer.MAX_VALUE);
         List<ProductOrderDto> productOrderDtos = new ArrayList<>();
         productOrderDtos.add(productOrderDto1);
 


### PR DESCRIPTION
## Resolve #175 

### 설명
- 마이페이지에서 주문내역 수를 노출할 때 사용할 총 주문 수를 반환하는 API를 구현했습니다.
- `/me/orders/all` 호출하면 `{ orderCount: int }` 형태로 반환합니다.
  ![스크린샷 2022-11-02 오후 2 39 10](https://user-images.githubusercontent.com/52682603/199407328-a757e913-400d-49d8-bafb-047f0520cba2.png)
- 값이 단순해서 별도 dto 만들지 않고 바로 map 으로 만들었습니다.

### 기타
- `TestDataLoader` 의 Product 재고가 열 개라 테스트 도중 `OutOfStockException` 이 발생하는 경우가 있어 재고 수량 수정했습니다.
- 관련해서 실패하는 테스트를 수정했습니다.
- `ProductOrder` 에 `quantity` 음수값 검증이 안되어 추가했습니다.
