### PR TITLE
refactor: 중복 데이터 저장 방지

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/DataLoader.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/DataLoader.java
@@ -39,13 +39,17 @@ public class DataLoader {
     private final ReviewRepository reviewRepository;
     private final NutritionRepository nutritionRepository;
 
-    private static final Map<String, Category> categories = new LinkedHashMap<>();
-    private static Product testProduct;
-    private static Member testMember;
+    private final Map<String, Category> categories = new LinkedHashMap<>();
+    private boolean categoryFlag = false;
+    private Product testProduct;
+    private Member testMember;
 
     @Transactional
     public void saveData(List<String[]> data) {
         saveCategory();
+        if (categoryFlag) {
+            return;
+        }
 
         List<Product> products = new ArrayList<>();
         for (String[] datum : data) {
@@ -170,6 +174,14 @@ public class DataLoader {
     }
 
     public void saveCategory() {
+        final List<Category> savedCategories = categoryRepository.findAll();
+        savedCategories.forEach((category -> categories.put(category.getName(), category)));
+
+        if (categories.size() > 0) {
+            categoryFlag = true;
+            return;
+        }
+
         Category category1 = categoryRepository.save(new Category("비스킷/샌드"));
         Category category2 = categoryRepository.save(new Category("스낵/봉지과자"));
         Category category3 = categoryRepository.save(new Category("박스과자"));


### PR DESCRIPTION
## Resolve #174 

### 설명
- 중복데이터가 계속 저장되는 기존 `DataLoader`를 수정했습니다.
- 카테고리 기준으로 8개의 카테고리가 모두 있으면 데이터를 추가하지 않고, 반대의 경우에 추가합니다.