### PR TITLE
feat: 회원의 총 쿠폰 수를 보여주는 api 추가, 테스트, api 문서 추가

### DIFF
--- a/backend/main-service/src/docs/asciidoc/coupon.adoc
+++ b/backend/main-service/src/docs/asciidoc/coupon.adoc
@@ -154,4 +154,14 @@ include::{snippets}/show-product-coupon-by-productId-and-memberId/http-request.a
 
 include::{snippets}/show-product-coupon-by-productId-and-memberId/http-response.adoc[]
 
+=== 회원별 쿠폰 총 수 조회
+
+- Request
+
+include::{snippets}/show-member-coupons-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/show-member-coupons-success/http-response.adoc[]
+
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
@@ -253,4 +253,8 @@ public class CouponService {
         return sortWithMaximumDiscountAmount.sort(couponProductResponseDtos);
 
     }
+
+    public int showMemberCouponCount(Long memberId) {
+        return memberCouponRepository.countByMemberId(memberId).intValue();
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
@@ -255,6 +255,6 @@ public class CouponService {
     }
 
     public int showMemberCouponCount(Long memberId) {
-        return memberCouponRepository.countByMemberId(memberId).intValue();
+        return memberCouponRepository.countAllByMemberIdAndIsUsedFalse(memberId);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/repository/MemberCouponRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/repository/MemberCouponRepository.java
@@ -28,7 +28,6 @@ public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long
     @Query("select mc from MemberCoupon mc where mc.coupon.priceRule = 'GRADE_COUPON' and mc.member.id = :memberId and mc.isUsed = false")
     List<MemberCoupon> findGradeCouponByMemberId(@Param(value = "memberId") Long memberId);
 
-    @Query("select count(mc) from MemberCoupon mc where mc.member.id = :memberId and mc.isUsed = false")
-    Long countByMemberId(@Param(value = "memberId") Long memberId);
+    int countAllByMemberIdAndIsUsedFalse(@Param(value = "memberId") Long memberId);
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/repository/MemberCouponRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/repository/MemberCouponRepository.java
@@ -28,4 +28,7 @@ public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long
     @Query("select mc from MemberCoupon mc where mc.coupon.priceRule = 'GRADE_COUPON' and mc.member.id = :memberId and mc.isUsed = false")
     List<MemberCoupon> findGradeCouponByMemberId(@Param(value = "memberId") Long memberId);
 
+    @Query("select count(mc) from MemberCoupon mc where mc.member.id = :memberId and mc.isUsed = false")
+    Long countByMemberId(@Param(value = "memberId") Long memberId);
+
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -1,9 +1,12 @@
 package kkakka.mainservice.member.member.ui;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import kkakka.mainservice.common.dto.NoOffsetPageInfo;
 import kkakka.mainservice.common.dto.PageableNoOffsetResponse;
+import kkakka.mainservice.coupon.application.CouponService;
 import kkakka.mainservice.member.auth.ui.AuthenticationPrincipal;
 import kkakka.mainservice.member.auth.ui.LoginMember;
 import kkakka.mainservice.member.auth.ui.MemberOnly;
@@ -33,6 +36,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final OrderService orderService;
+    private final CouponService couponService;
 
     @GetMapping("/health_check")
     public String status() {
@@ -84,5 +88,13 @@ public class MemberController {
                                 .map(MemberOrderDto::toResponseDto)
                                 .collect(Collectors.toList()), pageInfo)
         );
+    }
+
+    @GetMapping("me/coupons/all")
+    public ResponseEntity<Map<String, Integer>> showCouponCount(@AuthenticationPrincipal LoginMember loginMember) {
+        final int couponCount = couponService.showMemberCouponCount(loginMember.getId());
+        final Map<String, Integer> result = new HashMap<>();
+        result.put("couponCount", couponCount);
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/acceptance/CouponAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/acceptance/CouponAcceptanceTest.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.coupon.acceptance;
 
 import static kkakka.mainservice.fixture.TestDataLoader.PRODUCT_1;
+import static kkakka.mainservice.fixture.TestDataLoader.PRODUCT_2;
 import static kkakka.mainservice.fixture.TestMember.TEST_MEMBER_01;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
@@ -332,5 +333,28 @@ public class CouponAcceptanceTest extends DocumentConfiguration {
         // then
         Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         Assertions.assertThat(response.header("Location")).isNotNull();
+    }
+
+    @DisplayName("총 쿠폰 수 확인 - 성공")
+    @Test
+    void findMemberCouponCount_success() {
+        // given
+        String accessToken = 액세스_토큰_가져옴();
+        쿠폰_다운로드(accessToken);
+        쿠폰_다운로드2(accessToken);
+        쿠폰_생성함(null, PRODUCT_2.getId(), "COUPON", 14, 2000);
+        쿠폰_다운로드3(accessToken);
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured
+            .given(spec).log().all()
+            .filter(document("show-member-coupons-success"))
+            .header("Authorization", "Bearer " + accessToken)
+            .when()
+            .get("/api/members/me/coupons/all")
+            .then().log().all().extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
@@ -297,4 +297,38 @@ public class CouponServiceTest extends TestContext {
         // then
         assertThat(couponProductResponseDtos.size()).isEqualTo(1);
     }
+
+    @DisplayName("총 쿠폰 수 확인 - 성공")
+    @Test
+    void findMemberCouponCount_success() {
+        // given
+        Product product = new Product(null, null, "product",
+            1000, 20, "", "", "", null);
+        Member member = new Member();
+        productRepository.save(product);
+        memberRepository.save(member);
+        Long coupon1 = couponService.createCoupon(new CouponRequestDto(
+            null, null, product.getId(),
+            "test", "COUPON",
+            LocalDateTime.of(2020, 3, 16, 3, 16),
+            LocalDateTime.of(2025, 3, 16, 3, 16),
+            null, 2000, 10000
+        ));
+        Long coupon2 = couponService.createCoupon(new CouponRequestDto(
+            null, null, product.getId(),
+            "test", "COUPON",
+            LocalDateTime.of(2020, 3, 16, 3, 16),
+            LocalDateTime.of(2025, 3, 16, 3, 16),
+            null, 2000, 10000
+        ));
+        couponService.downloadCoupon(coupon1, member.getId());
+        couponService.downloadCoupon(coupon2, member.getId());
+        couponService.useCouponByMember(coupon1, member.getId());
+
+        // when
+        int count = couponService.showMemberCouponCount(member.getId());
+
+        // then
+        assertThat(count).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Resolve #188 

### 설명
- 총 쿠폰 수를 반환합니다.
- dto 생성 대신 HashMap 을 이용하여 `couponCount` 로 값을 넘겨줍니다.
- 데이터 불러오는 과정에서 `isUsed` 를 확인하여 사용하지 않은 쿠폰에 대한 수량만 전달합니다.

![image](https://user-images.githubusercontent.com/34434135/199869981-d0648133-46e2-4fcc-adc9-49d0e7443736.png)
