### PR TITLE
refactor: 응답에 사용하는 객체들 카멜 케이스로 통일

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartItemDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartItemDto.java
@@ -10,10 +10,10 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CartItemDto {
 
-    private Long id;
-    private Long productId;
-    private String productName;
-    private Integer productDiscount;
+    private Long cartItemId;
+    private Long id;  // product id
+    private String name;  // product name
+    private Integer discount;  // product discount
     private String imageUrl;
     private Integer quantity;
     private Integer price;

--- a/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/category/ui/dto/ResponseCategoryProducts.java
@@ -14,7 +14,6 @@ public class ResponseCategoryProducts {
     private Long id;
     private String name;
     private Integer price;
-    @JsonProperty("image_url")
     private String imageUrl;
     private Integer discount;
     private Date registeredAt;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/NutritionResponse.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/NutritionResponse.java
@@ -16,9 +16,7 @@ public class NutritionResponse {
     private String sugar;
     private String protein;
     private String fat;
-    @JsonProperty(value = "saturated_fat")
     private String saturatedFat;
-    @JsonProperty(value = "trans_fat")
     private String transFat;
     private String cholesterol;
     private String sodium;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductDetailResponse.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductDetailResponse.java
@@ -16,11 +16,8 @@ public class ProductDetailResponse {
     private String name;
     private Integer price;
     private Integer stock;
-    @JsonProperty("image_url")
     private String imageUrl;
-    @JsonProperty("detailImage_url")
     private String detailImageUrl;
-    @JsonProperty("nutritionInfo_url")
     private String nutritionInfoUrl;
     private int discount;
     @JsonProperty("nutrition")

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponse.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/ui/dto/ProductResponse.java
@@ -16,11 +16,8 @@ public class ProductResponse {
     private String name;
     private Integer price;
     private Integer stock;
-    @JsonProperty("image_url")
     private String imageUrl;
-    @JsonProperty("detailImage_url")
     private String detailImageUrl;
-    @JsonProperty("nutritionInfo_url")
     private String nutritionInfoUrl;
     private int discount;
     private double ratingAvg;

--- a/backend/main-service/src/test/java/kkakka/mainservice/cart/ui/CartAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/cart/ui/CartAcceptanceTest.java
@@ -103,7 +103,7 @@ class CartAcceptanceTest extends DocumentConfiguration {
         장바구니_추가함(accessToken, PRODUCT_2.getId(), 1);
         final CartResponseDto cart = 장바구니에서_찾아옴(accessToken);
         퍼센트_쿠폰_생성();
-        장바구니_쿠폰_적용(cart.getCartItemDtos().get(0).getId(),1L,accessToken);
+        장바구니_쿠폰_적용(cart.getCartItemDtos().get(0).getCartItemId(),1L,accessToken);
 
         //when
         ExtractableResponse<Response> response = RestAssured.given(spec).log().all()
@@ -147,7 +147,7 @@ class CartAcceptanceTest extends DocumentConfiguration {
         final CartResponseDto cartResponseDto = 장바구니에서_찾아옴(accessToken);
         assertThat(
                 cartResponseDto.getCartItemDtos().stream()
-                        .filter(cartItemDto -> cartItemDto.getProductId().equals(PRODUCT_1.getId()))
+                        .filter(cartItemDto -> cartItemDto.getId().equals(PRODUCT_1.getId()))
                         .findAny().orElseThrow()
                         .getQuantity()
         ).isEqualTo(3);
@@ -169,7 +169,7 @@ class CartAcceptanceTest extends DocumentConfiguration {
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .delete("/api/carts/" + cart.getCartItemDtos().get(0).getId())
+                .delete("/api/carts/" + cart.getCartItemDtos().get(0).getCartItemId())
                 .then()
                 .log().all().extract();
 
@@ -192,7 +192,7 @@ class CartAcceptanceTest extends DocumentConfiguration {
                 .filter(document("applyCartItemCoupon-success"))
                 .header("Authorization", "Bearer " + accessToken)
                 .when()
-                .post("/api/carts/" + cart.getCartItemDtos().get(0).getId() + "/" + couponId)
+                .post("/api/carts/" + cart.getCartItemDtos().get(0).getCartItemId() + "/" + couponId)
                 .then().log().all().extract();
 
         //then


### PR DESCRIPTION
## Resolve #191 

### 설명
- API 응답 객체의 필드를 모두 카멜 케이스로 통일했습니다.