### PR TITLE
feat: 추천 API 메인페이지에 적용

### DIFF
--- a/frontend/components/main/RecommCard.js
+++ b/frontend/components/main/RecommCard.js
@@ -4,8 +4,8 @@ import RecommRec from "./RecommRec";
 export default function RecommCard({ id, imgsrc, name, price, discount }) {
   return (
     <>
-      <RecommRec />
-      <RecommInfo />
+      <RecommRec id={id} imgsrc={imgsrc}/>
+      <RecommInfo id={id} name={name} price={price} discount={15}/>
     </>
   );
 }
@@ -15,5 +15,5 @@ RecommCard.defaultProps = {
   imgsrc: "/sample.png",
   name: "test",
   price: 10000,
-  rate: 10,
+  discount: 10,
 };

--- a/frontend/components/main/RecommCard.js
+++ b/frontend/components/main/RecommCard.js
@@ -5,7 +5,7 @@ export default function RecommCard({ id, imgsrc, name, price, discount }) {
   return (
     <>
       <RecommRec id={id} imgsrc={imgsrc}/>
-      <RecommInfo id={id} name={name} price={price} discount={15}/>
+      <RecommInfo id={id} name={name} price={price} discount={discount}/>
     </>
   );
 }

--- a/frontend/components/main/RecommInfo.js
+++ b/frontend/components/main/RecommInfo.js
@@ -1,59 +1,147 @@
 import Link from "next/link";
-import { NBlack } from "../../typings/NormalColor";
-import { ThemeRed } from "../../typings/ThemeColor";
+import {NBlack} from "../../typings/NormalColor";
+import {ThemeRed} from "../../typings/ThemeColor";
+import {useMoney} from "../../hooks/useMoney";
 
-export default function RecommInfo({ id, name }) {
+export default function RecommInfo({id, name, price, discount}) {
   return (
-    <>
-      <div className="wrapper">
-        <Link href={`/product/productDetail?id=${id}`}>
-          <a>
-            <div style={{ marginTop: "5%" }}>
-              <p
-                style={{
-                  fontSize: "16px",
-                  fontWeight: "700",
-                  color: "#3a3a3a",
-                  height: "50px",
-                }}
-              >
-                {name}
-              </p>
-            </div>
-          </a>
-        </Link>
-      </div>
+      <>
+        <div className="wrapper">
+          <Link href={`/product/productDetail?id=${id}`}>
+            <a>
+              <div style={{marginTop: "5%"}}>
+                <p
+                    className="name"
+                >
+                  {name}
+                </p>
+                {discount !== 0 ? (
+                    <>
+                      <div
+                          className="priceRate"
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between"
+                          }}
+                      >
+                        <div style={{
+                          width: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          alignItems: "flex-start"
+                        }}>
+                          <span className="discount">{useMoney(price)}원</span>
+                          <span>
+                        {useMoney(Math.ceil(price * (1 - discount * 0.01)))}원
+                          </span>
+                        </div>
+                        <span style={{color: `${ThemeRed}`}}>{discount}%</span>
+                      </div>
+                    </>
+                ) : (
+                    <>
+                      <div
+                          className="priceRate"
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between"
+                          }}
+                      >
+                        <div style={{
+                          width: "100%",
+                          display: "flex",
+                          flexDirection: "column",
+                          alignItems: "flex-start"
+                        }}>
+                          <span className="blank"></span>
+                          <span>{useMoney(price)}원</span>
+                        </div>
+                      </div>
+                    </>
+                )}
+              </div>
+            </a>
+          </Link>
+        </div>
 
-      <style jsx>{`
+        <style jsx>{`
         @media screen and (min-width: 769px) {
           /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
           .wrapper {
-            .priceRate {
-              font-size: 50px;
-              font-weight: 700;
-              color: ${NBlack};
-              margin: 0;
+            p {
+              margin: 16px 0;
             }
+
+            margin-top: 15px;
+            .name {
+              font-size: 1.2rem;
+              font-weight: 700;
+              color: #3a3a3a;
+              height: 50px;
+            }
+
+            .discount {
+              font-size: 14px;
+              font-weight: 600;
+              color: #898989;
+              text-decoration: line-through;
+            }
+
+            .blank {
+              height: 19px;
+            }
+          }
+          
+          .priceRate {
+            font-size: 1.3rem;
+            font-weight: 700;
+            color: ${NBlack};
+            padding: 0 7rem
           }
         }
 
         @media screen and (max-width: 768px) {
           /* 모바일에 사용될 스트일 시트를 여기에 작성합니다. */
           .wrapper {
-            .priceRate {
+            p {
+              margin: 16px 0 8px 0;
+            }
+
+            margin-top: 15px;
+            .name {
               font-size: 2.63vw;
               font-weight: 700;
-              color: ${NBlack};
-              margin: 0;
+              color: #3a3a3a;
             }
+
+            .discount {
+              font-size: 2.0vw;
+              font-weight: 600;
+              color: #898989;
+              text-decoration: line-through;
+            }
+
+            .blank {
+              height: 10px;
+            }
+          }
+          
+          .priceRate {
+            font-size: 2.63vw;
+            font-weight: 700;
+            color: ${NBlack};
+            margin: 0;
+            padding: 0 4vw;
           }
         }
       `}</style>
-    </>
+      </>
   );
 }
 
 RecommInfo.defaultProps = {
   id: 1,
   name: "샘플",
+  price: 10000,
+  discount: 10
 };

--- a/frontend/components/main/RecommRec.js
+++ b/frontend/components/main/RecommRec.js
@@ -23,7 +23,7 @@ export default function RecommRec({ id, imgsrc, name, price, discount }) {
               background-color: #f5f5f5;
 
               img {
-                height: 330px;
+                height: 280px;
               }
             }
           }

--- a/frontend/components/main/RecommSlider.js
+++ b/frontend/components/main/RecommSlider.js
@@ -22,7 +22,7 @@ export default function RecommSlider({tab, handleTab}) {
   const [recommendProducts, setRecommendProducts] = useState([]);
   const [reviewProducts, setReviewProducts] = useState([]);
 
-  const slideSize = 5;
+  const SLIDE_SIZE = 5;
 
   function handleRecToggle() {
     if (tab === "맞춤" && recommToggle) {
@@ -41,7 +41,7 @@ export default function RecommSlider({tab, handleTab}) {
   }
 
   const getRecommendProducts = async () => {
-    await axios.get(`/api/products/recommend?size=${slideSize}`, {
+    await axios.get(`/api/products/recommend?size=${SLIDE_SIZE}`, {
       headers: {
         Authorization: `Bearer ${useGetToken()}`,
       },
@@ -58,7 +58,7 @@ export default function RecommSlider({tab, handleTab}) {
 
   const getReviewProducts = async () => {
     await axios
-    .get(`/api/products?sortBy=BEST&size=${slideSize}`)
+    .get(`/api/products?sortBy=BEST&size=${SLIDE_SIZE}`)
     .then((res) => {
       setReviewProducts(res.data.data)
     });
@@ -111,7 +111,7 @@ export default function RecommSlider({tab, handleTab}) {
                   loop={true}
                   spaceBetween={10}
                   centeredSlides={true}
-                  slidesPerView={slideSize}
+                  slidesPerView={SLIDE_SIZE}
                   cssMode={true}
                   navigation={{
                     prevEl: navigationPrevRef.current,

--- a/frontend/components/main/RecommSlider.js
+++ b/frontend/components/main/RecommSlider.js
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import {useEffect, useRef, useState} from "react";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
@@ -9,14 +9,20 @@ import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
 import RecommCard from "./RecommCard";
+import { useGetToken } from "../../hooks/useGetToken";
+import axios from "axios";
 
-export default function RecommSlider({ tab, handleTab }) {
+export default function RecommSlider({tab, handleTab}) {
   SwiperCore.use([Autoplay, Navigation, Pagination]);
   const [swiper, setSwiper] = useState(null);
   const navigationPrevRef = useRef(null);
   const navigationNextRef = useRef(null);
   const [recommToggle, setRecommToggle] = useState(true);
   const [reviewToggle, setReviewToggle] = useState(true);
+  const [recommendProducts, setRecommendProducts] = useState([]);
+  const [reviewProducts, setReviewProducts] = useState([]);
+
+  const slideSize = 5;
 
   function handleRecToggle() {
     if (tab === "맞춤" && recommToggle) {
@@ -33,6 +39,36 @@ export default function RecommSlider({ tab, handleTab }) {
       setReviewToggle(true);
     }
   }
+
+  const getRecommendProducts = async () => {
+    await axios.get(`/api/products/recommend?size=${slideSize}`, {
+      headers: {
+        Authorization: `Bearer ${useGetToken()}`,
+      },
+    })
+    .then((res) => {
+      setRecommendProducts(res.data.data)
+      return res;
+    })
+    .catch(function (error) {
+      console.log(error);
+      return {};
+    });
+  };
+
+  const getReviewProducts = async () => {
+    await axios
+    .get(`/api/products?sortBy=BEST&size=${slideSize}`)
+    .then((res) => {
+      setReviewProducts(res.data.data)
+    });
+  }
+
+  useEffect(() => {
+    console.log('loaded!')
+    getRecommendProducts();
+    getReviewProducts()
+  }, [recommToggle, reviewToggle]);
 
   return (
     <>
@@ -75,7 +111,7 @@ export default function RecommSlider({ tab, handleTab }) {
                   loop={true}
                   spaceBetween={10}
                   centeredSlides={true}
-                  slidesPerView={5}
+                  slidesPerView={slideSize}
                   cssMode={true}
                   navigation={{
                     prevEl: navigationPrevRef.current,
@@ -84,7 +120,6 @@ export default function RecommSlider({ tab, handleTab }) {
                   onInit={(swiper) => {
                     swiper.params.navigation.prevEl = navigationPrevRef.current;
                     swiper.params.navigation.nextEl = navigationNextRef.current;
-
                     swiper.navigation.init();
                     swiper.navigation.update();
                   }}
@@ -97,96 +132,90 @@ export default function RecommSlider({ tab, handleTab }) {
                   modules={[Autoplay, Navigation, Pagination, Keyboard]}
                   ref={setSwiper}
                 >
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
+                  <>
+                    {recommendProducts.map((product, idx) => {
+                      return (
+                          <SwiperSlide key={idx} className="swiper-slide">
+                            <RecommCard id={product.id} name={product.name}
+                                        imgsrc={product.image_url} price={product.price}
+                                        discount={product.discount}
+                            />
+                          </SwiperSlide>
+                      )
+                    })}
+                  </>
                 </Swiper>
               </div>
 
-              <div className="swiper-pagination"></div>
-              <div className="swiper-prev">
-                <ArrowBackIcon ref={navigationPrevRef} />
-              </div>
-              <div className="swiper-next">
-                <ArrowForwardIcon ref={navigationNextRef} />
-              </div>
-            </div>
-          </>
-        )}
-        {tab === "리뷰" && (
-          <>
-            <div className={reviewToggle ? "promotion" : "promotion hide"}>
-              <div className="swiper-container">
-                <Swiper
-                  className="swiper-wrapper"
-                  loop={true}
-                  spaceBetween={20}
-                  centeredSlides={true}
-                  slidesPerView={5} // 한 슬라이드에 보여줄 갯수
-                  cssMode={true}
-                  navigation={{
-                    prevEl: navigationPrevRef.current,
-                    nextEl: navigationNextRef.current,
-                  }}
-                  onInit={(swiper) => {
-                    swiper.params.navigation.prevEl = navigationPrevRef.current;
-                    swiper.params.navigation.nextEl = navigationNextRef.current;
+                  <div className="swiper-pagination"></div>
+                  <div className="swiper-prev">
+                    <ArrowBackIcon ref={navigationPrevRef} />
+                  </div>
+                  <div className="swiper-next">
+                    <ArrowForwardIcon ref={navigationNextRef} />
+                  </div>
+                </div>
+              </>
+          )}
+          {tab === "리뷰" && (
+              <>
+                <div className={reviewToggle ? "promotion" : "promotion hide"}>
+                  <div className="swiper-container">
+                    <Swiper
+                        className="swiper-wrapper"
+                        loop={true}
+                        spaceBetween={20}
+                        centeredSlides={true}
+                        slidesPerView={5} // 한 슬라이드에 보여줄 갯수
+                        cssMode={true}
+                        navigation={{
+                          prevEl: navigationPrevRef.current,
+                          nextEl: navigationNextRef.current,
+                        }}
+                        onInit={(swiper) => {
+                          swiper.params.navigation.prevEl = navigationPrevRef.current;
+                          swiper.params.navigation.nextEl = navigationNextRef.current;
 
-                    swiper.navigation.init();
-                    swiper.navigation.update();
-                  }}
-                  onSwiper={setSwiper}
-                  autoplay={{
-                    delay: 2500,
-                  }}
-                  pagination={true}
-                  keyboard={true}
-                  modules={[Autoplay, Navigation, Pagination, Keyboard]}
-                  ref={setSwiper}
-                >
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                  <SwiperSlide className="swiper-slide">
-                    <RecommCard />
-                  </SwiperSlide>
-                </Swiper>
-              </div>
+                          swiper.navigation.init();
+                          swiper.navigation.update();
+                        }}
+                        onSwiper={setSwiper}
+                        autoplay={{
+                          delay: 2500,
+                        }}
+                        pagination={true}
+                        keyboard={true}
+                        modules={[Autoplay, Navigation, Pagination, Keyboard]}
+                        ref={setSwiper}
+                    >
+                      <>
+                        {reviewProducts.map((product, idx) => {
+                          return (
+                              <SwiperSlide key={idx} className="swiper-slide">
+                                <RecommCard id={product.id} name={product.name}
+                                            imgsrc={product.image_url} price={product.price}
+                                            discount={product.discount}
+                                />
+                              </SwiperSlide>
+                          )
+                        })}
+                      </>
+                    </Swiper>
+                  </div>
 
-              <div className="swiper-pagination"></div>
-              <div className="swiper-prev">
-                <ArrowBackIcon ref={navigationPrevRef} />
-              </div>
-              <div className="swiper-next">
-                <ArrowForwardIcon ref={navigationNextRef} />
-              </div>
-            </div>
-          </>
-        )}
-      </section>
+                  <div className="swiper-pagination"></div>
+                  <div className="swiper-prev">
+                    <ArrowBackIcon ref={navigationPrevRef}/>
+                  </div>
+                  <div className="swiper-next">
+                    <ArrowForwardIcon ref={navigationNextRef}/>
+                  </div>
+                </div>
+              </>
+          )}
+        </section>
 
-      <style jsx>{`
+        <style jsx>{`
         @media screen and (min-width: 769px) {
           /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
           .notice {
@@ -507,6 +536,6 @@ export default function RecommSlider({ tab, handleTab }) {
           }
         }
       `}</style>
-    </>
+      </>
   );
 }

--- a/frontend/components/main/RecommSlider.js
+++ b/frontend/components/main/RecommSlider.js
@@ -94,7 +94,7 @@ export default function RecommSlider({tab, handleTab}) {
                 handleRevToggle();
               }}
             >
-              <h2>리뷰 추천</h2>
+              <h2>별점 추천</h2>
               <div className="toggle-promotion">
                 <ArrowDropDownIcon />
               </div>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -7,7 +7,7 @@ import Introduction from "../components/main/Introduction";
 import RecommSlider from "../components/main/RecommSlider";
 
 export default function Home() {
-  const [tab, setTab] = useState("리뷰");
+  const [tab, setTab] = useState("맞춤");
 
   function handleTab(text) {
     setTab(text);


### PR DESCRIPTION
## Resolve #62 

### 설명
- 앞서 구현한 추천 API 를 프론트엔드에 연동하여 메인페이지에서 확인할 수 있도록 구현했습니다.
- 실제로 구동하면 `리뷰 추천` 대신 `별점 추천` 으로 출력됩니다.
- 할인이 적용 됐을 때 / 되지 않았을 때 다르게 만들었습니다.
![스크린샷 2022-11-07 오전 11 41 44](https://user-images.githubusercontent.com/52682603/200222619-fed5ed45-9725-4eb0-a9a6-cb8c4d7b2a06.png)
![스크린샷 2022-11-07 오전 11 41 56](https://user-images.githubusercontent.com/52682603/200222629-64f9fe7b-ead4-4cc9-b70e-cc0b7bbcee0d.png)
