### PR TITLE
feat: 장바구니 아이템 총 수 조회 구현

### DIFF
--- a/backend/main-service/src/docs/asciidoc/auth_member.adoc
+++ b/backend/main-service/src/docs/asciidoc/auth_member.adoc
@@ -89,3 +89,14 @@ include::{snippets}/orders-info-member-count-success/http-request.adoc[]
 - Response
 
 include::{snippets}/orders-info-member-count-success/http-response.adoc[]
+
+
+=== 회원 총 장바구니 아이템 수 조회
+
+- Request
+
+include::{snippets}/cart-item-count-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/cart-item-count-success/http-response.adoc[]

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -9,6 +9,7 @@ import kkakka.mainservice.cart.ui.dto.CartRequestDto;
 import kkakka.mainservice.cart.ui.dto.CartResponseDto;
 import kkakka.mainservice.cart.ui.dto.CouponDto;
 import kkakka.mainservice.common.exception.KkaKkaException;
+import kkakka.mainservice.common.exception.NotFoundMemberException;
 import kkakka.mainservice.common.exception.NotOrderOwnerException;
 import kkakka.mainservice.coupon.domain.Coupon;
 import kkakka.mainservice.coupon.domain.repository.CouponRepository;
@@ -99,5 +100,11 @@ public class CartService {
     private Cart findOrCreateCart(Member member) {
         return cartRepository.findByMemberId(member.getId())
                 .orElseGet(() -> cartRepository.save(new Cart(member)));
+    }
+
+    public int showCartItemCount(Long id) {
+        final Member member = memberRepository.findById(id)
+                .orElseThrow(NotFoundMemberException::new);
+        return cartItemRepository.countAllByMemberId(member.getId());
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.cart.domain.repository;
 
 import kkakka.mainservice.cart.domain.CartItem;
+import lombok.extern.java.Log;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +15,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
     @Query("select ci from CartItem ci join fetch ci.cart join ci.cart.member m where ci.id = :cartItemId and m.id = :memberId")
     Optional<CartItem> findByIdandMemberId(@Param("cartItemId") Long cartId, @Param("memberId") Long memberId);
+
+    @Query("select count(ci) from CartItem ci where ci.cart.member.id = :memberId")
+    int countAllByMemberId(Long memberId);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/member/member/ui/MemberController.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kkakka.mainservice.cart.application.CartService;
 import kkakka.mainservice.common.dto.NoOffsetPageInfo;
 import kkakka.mainservice.common.dto.PageableNoOffsetResponse;
 import kkakka.mainservice.member.auth.ui.AuthenticationPrincipal;
@@ -35,6 +36,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final OrderService orderService;
+    private final CartService cartService;
 
     @GetMapping("/health_check")
     public String status() {
@@ -89,10 +91,20 @@ public class MemberController {
     }
 
     @GetMapping("/me/orders/all")
-    public ResponseEntity<Map<String, Integer>> showOrderCount(@AuthenticationPrincipal LoginMember loginMember) {
+    public ResponseEntity<Map<String, Integer>> showOrderCount(
+            @AuthenticationPrincipal LoginMember loginMember) {
         final int orderCount = orderService.showMemberOrderCount(loginMember.getId());
         final Map<String, Integer> result = new HashMap<>();
         result.put("orderCount", orderCount);
+        return ResponseEntity.ok().body(result);
+    }
+
+    @GetMapping("/me/carts/all")
+    public ResponseEntity<Map<String, Integer>> showCartCount(
+            @AuthenticationPrincipal LoginMember loginMember) {
+        final int cartItemCount = cartService.showCartItemCount(loginMember.getId());
+        final Map<String, Integer> result = new HashMap<>();
+        result.put("cartCount", cartItemCount);
         return ResponseEntity.ok().body(result);
     }
 }


### PR DESCRIPTION
## Resolve #202 

### 설명
- 현지 장바구니에 담긴 `cartItem` 기준으로 조회합니다.
- `GET /api/members/me/carts/all` 로 요청합니다. 기존의 주문 총 수 API 와 형식이 비슷합니다.
- `cartCount` 에 `number` 값을 담아 반환합니다.
- 한 장바구니 아이템에 대해 입력한 수량은 고려하지 않습니다. 
