### PR TITLE
fix: product discount 값 계산 수정

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
@@ -246,20 +246,20 @@ public class CouponService {
 
     private List<CouponProductResponseDto> sortWithMaximumDiscountAmount(
         List<CouponProductResponseDto> couponProductResponseDtos, Product product) {
+        int discountedProductPrice = (int) Math.ceil(
+            product.getPrice() * (1 - (product.getDiscount() * 0.01)));
         for (CouponProductResponseDto couponProductResponseDto : couponProductResponseDtos) {
             if (couponProductResponseDto.getPercentage() != null) {
                 int calculatedPercentValue = calculatePercentage
-                    .apply(product.getPrice() - product.getDiscount(),
-                        couponProductResponseDto.getPercentage());
+                    .apply(discountedProductPrice, couponProductResponseDto.getPercentage());
                 int calculatedStaticValue = calculateStaticPrice
-                    .apply(product.getPrice() - product.getDiscount(),
-                        couponProductResponseDto.getMaxDiscount());
+                    .apply(discountedProductPrice, couponProductResponseDto.getMaxDiscount());
                 couponProductResponseDto.saveDiscountedPrice(
                     Math.max(calculatedPercentValue, calculatedStaticValue));
                 continue;
             }
             couponProductResponseDto.saveDiscountedPrice(
-                calculateStaticPrice.apply(product.getPrice() - product.getDiscount(),
+                calculateStaticPrice.apply(discountedProductPrice,
                     couponProductResponseDto.getMaxDiscount()));
         }
         return couponProductResponseDtos;


### PR DESCRIPTION
## Resolve 

### 설명
- `product` 의 할인 값을 `product.getPrice - product.getDiscount` 로 계산 하던 부분을 `product.getPrice * (1 - product.getPercentage * 0.01)` 로 계산하도록 수정

### 기타
