### PR TITLE
feat: DB-Replication 적용

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/common/replication/DataSourceType.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/replication/DataSourceType.java
@@ -1,0 +1,5 @@
+package kkakka.mainservice.common.replication;
+
+public enum DataSourceType {
+    Primary, Secondary
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/replication/ReplicationDataBaseConfig.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/replication/ReplicationDataBaseConfig.java
@@ -1,0 +1,57 @@
+package kkakka.mainservice.common.replication;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Profile("dev")
+@Configuration
+@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
+@EnableTransactionManagement
+public class ReplicationDataBaseConfig {
+
+    @Bean(name = "primaryDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.primary")
+    public DataSource primaryDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean(name = "secondaryDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.secondary")
+    public DataSource secondaryDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(DataSource primaryDataSource, DataSource secondaryDataSource) {
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+
+        dataSourceMap.put(DataSourceType.Primary, primaryDataSource);
+        dataSourceMap.put(DataSourceType.Secondary, secondaryDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(primaryDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        return new LazyConnectionDataSourceProxy(routingDataSource(primaryDataSource(), secondaryDataSource()));
+    }
+}

--- a/backend/main-service/src/main/java/kkakka/mainservice/common/replication/ReplicationRoutingDataSource.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/common/replication/ReplicationRoutingDataSource.java
@@ -1,0 +1,18 @@
+package kkakka.mainservice.common.replication;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Profile("dev")
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        if (isReadOnly) {
+            return DataSourceType.Secondary;
+        }
+        return DataSourceType.Primary;
+    }
+}


### PR DESCRIPTION
## Resolve #195 
쿠버네티스 안에서의 데이터베이스 고가용성 구성을 위한 Mysql - Operator 패턴을 적용하였습니다. ( Master - Slave 설정과 비슷합니다. )
ReadWrite 를 할 수있는 Primary 1대와 ReadOnly 만 할 수있는 Secondary 2대로 구성되어있습니다.
mysql-router 라는 endpoint의 Port로 역할을 구분합니다.
Port : 6446 - ReadWrite DB , Port 6447 : ReadOnly DB
![image](https://user-images.githubusercontent.com/48666403/200531321-67509327-0684-4a79-8b29-62da438b6daf.png)


### 설명
1. DataSourceAutoConfiguration class의 수동설정을 통해 primary,secondary datasource 들을 매핑합니다.
2. TransactionSynchronizationManager.isCurrentTransactionReadOnly 를 통해 현재 사용중인 트랜잭션이 ReadOnly 인지 확인합니다.
3. ReadOnly 이면 ReadOnly만 가능한 Secondary DB의 datasource를 이용하고 insert,update,delete 등의 트랜잭션이면 Write의 권한을 가진 Primary DB의 datasource를 이용합니다.
4. 스프링은 트랜잭션에 진입하는 순간 설정된 Datasource의 커넥션을 가져오기 때문에 LazyConnectionDataSourceProxy 를 이용하여 Transaction ReadOnly 값에따라 원하는 Datasource 의 값을 이용합니다.
5. dev 환경에서만 돌아갈 수 있도록 Profile을 추가하였습니다.

정상 동작 확인
Seclect 쿼리 시 Secondary DB 이용
![image](https://user-images.githubusercontent.com/48666403/200530094-16336126-1406-4146-981d-76522ae1b594.png)
![image](https://user-images.githubusercontent.com/48666403/200530120-dfe9f075-5443-4208-94f0-a4feb40f309a.png)

기타 쓰기,수정,삭제 쿼리 시 Primary DB 이용
![image](https://user-images.githubusercontent.com/48666403/200530392-ef326a7f-6d30-4329-bf27-691d262d15d3.png)
![image](https://user-images.githubusercontent.com/48666403/200530537-3940c7ac-9a52-4c7c-b282-6e798f3ce79b.png)
