### PR TITLE
feat: 사용한 쿠폰 조회 api 구현

### DIFF
--- a/backend/main-service/src/docs/asciidoc/coupon.adoc
+++ b/backend/main-service/src/docs/asciidoc/coupon.adoc
@@ -93,6 +93,47 @@ include::{snippets}/download-coupon/http-request.adoc[]
 
 include::{snippets}/download-coupon/http-response.adoc[]
 
+=== 비회원 상품 적용 가능한 쿠폰 조회
+
+- Request
+
+include::{snippets}/show-product-coupon-by-productId/http-request.adoc[]
+
+- Response
+
+include::{snippets}/show-product-coupon-by-productId/http-response.adoc[]
+
+=== 회원 상품 적용 가능한 쿠폰 조회
+
+- Request
+
+include::{snippets}/show-product-coupon-by-productId-and-memberId/http-request.adoc[]
+
+- Response
+
+include::{snippets}/show-product-coupon-by-productId-and-memberId/http-response.adoc[]
+
+=== 회원별 쿠폰 총 수 조회
+
+- Request
+
+include::{snippets}/show-member-coupons-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/show-member-coupons-success/http-response.adoc[]
+
+=== 사용한 쿠폰 조회
+
+- Request
+
+include::{snippets}/find-used-coupons/http-request.adoc[]
+
+- Response
+
+include::{snippets}/find-used-coupons/http-response.adoc[]
+
+
 == Discount
 === 상품 할인 생성
 
@@ -133,35 +174,3 @@ include::{snippets}/show-discounts-success/http-request.adoc[]
 - Response
 
 include::{snippets}/show-discounts-success/http-response.adoc[]
-
-=== 비회원 상품 적용 가능한 쿠폰 조회
-
-- Request
-
-include::{snippets}/show-product-coupon-by-productId/http-request.adoc[]
-
-- Response
-
-include::{snippets}/show-product-coupon-by-productId/http-response.adoc[]
-
-=== 회원 상품 적용 가능한 쿠폰 조회
-
-- Request
-
-include::{snippets}/show-product-coupon-by-productId-and-memberId/http-request.adoc[]
-
-- Response
-
-include::{snippets}/show-product-coupon-by-productId-and-memberId/http-response.adoc[]
-
-=== 회원별 쿠폰 총 수 조회
-
-- Request
-
-include::{snippets}/show-member-coupons-success/http-request.adoc[]
-
-- Response
-
-include::{snippets}/show-member-coupons-success/http-response.adoc[]
-
-

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/application/CouponService.java
@@ -183,7 +183,7 @@ public class CouponService {
         }
     }
 
-    /* 사용자 사용 가능한 쿠폰 목록 조회 */
+    /* 회원 사용 가능한 쿠폰 목록 조회 */
     public List<Coupon> findUsableCoupons(Long memberId) {
         List<MemberCoupon> memberCoupons = memberCouponRepository
             .findAllByMemberIdAndIsUsedFalse(memberId);
@@ -192,7 +192,16 @@ public class CouponService {
             .collect(Collectors.toList());
     }
 
-    /* 사용자 다운 가능한 쿠폰 목록 조회 */
+    /* 회원 사용한 쿠폰 목록 조회 */
+    public List<Coupon> findUsedCoupons(Long memberId) {
+        List<MemberCoupon> memberCoupons = memberCouponRepository
+            .findAllByMemberIdAndIsUsedTrue(memberId);
+        return memberCoupons.stream()
+            .map(memberCoupon -> memberCoupon.getCoupon())
+            .collect(Collectors.toList());
+    }
+
+    /* 회원 다운 가능한 쿠폰 목록 조회 */
     public List<CouponResponseDto> findDownloadableCoupons(Long memberId) {
         List<Coupon> coupons = couponRepository.findAll();
         List<Coupon> downloadedCoupons = memberCouponRepository.findAllByMemberId(

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/repository/MemberCouponRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/repository/MemberCouponRepository.java
@@ -12,6 +12,9 @@ public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long
     @Query("select mc from MemberCoupon mc join fetch mc.coupon where mc.member.id = :memberId and mc.isUsed = false")
     List<MemberCoupon> findAllByMemberIdAndIsUsedFalse(@Param(value = "memberId") Long memberId);
 
+    @Query("select mc from MemberCoupon mc join fetch mc.coupon where mc.member.id = :memberId and mc.isUsed = true")
+    List<MemberCoupon> findAllByMemberIdAndIsUsedTrue(@Param(value = "memberId") Long memberId);
+
     @Query("select mc.coupon from MemberCoupon mc where mc.member.id = :memberId")
     List<Coupon> findAllByMemberId(@Param(value = "memberId") Long memberId);
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/ui/CouponController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/ui/CouponController.java
@@ -70,10 +70,21 @@ public class CouponController {
     }
 
     /* 사용 가능한 쿠폰 조회 */
-    @GetMapping("/me")
+    @GetMapping("/me/available")
     public ResponseEntity<List<CouponResponseDto>> findUsableCoupons(
         @AuthenticationPrincipal LoginMember loginMember) {
         List<CouponResponseDto> coupons = couponService.findUsableCoupons(loginMember.getId())
+            .stream()
+            .map(coupon -> CouponResponseDto.create(coupon))
+            .collect(Collectors.toList());
+        return ResponseEntity.status(HttpStatus.OK).body(coupons);
+    }
+
+    /* 사용한 쿠폰 조회 */
+    @GetMapping("/me/unavailable")
+    public ResponseEntity<List<CouponResponseDto>> findUsedCoupons(
+        @AuthenticationPrincipal LoginMember loginMember) {
+        List<CouponResponseDto> coupons = couponService.findUsedCoupons(loginMember.getId())
             .stream()
             .map(coupon -> CouponResponseDto.create(coupon))
             .collect(Collectors.toList());
@@ -117,5 +128,13 @@ public class CouponController {
         List<CouponProductResponseDto> couponResponseDtos = couponService.showCouponsByProductId(
             productId);
         return ResponseEntity.status(HttpStatus.OK).body(couponResponseDtos);
+    }
+
+    /* 쿠폰 사용 */
+    @PostMapping("/use/{couponId}")
+    public ResponseEntity<Void> useCoupon(@PathVariable Long couponId,
+        @AuthenticationPrincipal LoginMember loginMember) {
+        couponService.useCouponByMember(couponId, loginMember.getId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/acceptance/CouponAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/acceptance/CouponAcceptanceTest.java
@@ -160,11 +160,39 @@ public class CouponAcceptanceTest extends DocumentConfiguration {
             .header("Authorization", "Bearer " + accessToken)
             .filter(document("find-usable-coupons"))
             .when()
-            .get("/api/coupons/me")
+            .get("/api/coupons/me/available")
             .then().log().all().extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.body()).isNotNull();
+    }
+
+    @DisplayName("회원별 사용한 쿠폰 조회 - 성공")
+    @Test
+    void usedCoupons() {
+        String accessToken = 액세스_토큰_가져옴();
+        String couponId = 상품_쿠폰_다운로드(accessToken);
+        쿠폰_사용(couponId, accessToken);
+
+        final ExtractableResponse<Response> response = RestAssured
+            .given(spec).log().all()
+            .header("Authorization", "Bearer " + accessToken)
+            .filter(document("find-used-coupons"))
+            .when()
+            .get("/api/coupons/me/unavailable")
+            .then().log().all().extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body()).isNotNull();
+    }
+
+    private void 쿠폰_사용(String couponId, String accessToken) {
+        final ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .header("Authorization", "Bearer " + accessToken)
+            .when()
+            .post("/api/coupons/use/" + couponId)
+            .then().log().all().extract();
     }
 
     private String 쿠폰_생성함(String grade, Long productId, String priceRule, Integer percentage,

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
@@ -42,8 +42,6 @@ public class CouponServiceTest extends TestContext {
     MemberCouponRepository memberCouponRepository;
     @Autowired
     MemberRepository memberRepository;
-    @PersistenceContext
-    private EntityManager entityManager;
 
     @Test
     @DisplayName("쿠폰 사용 여부 확인 - 성공")
@@ -330,5 +328,31 @@ public class CouponServiceTest extends TestContext {
 
         // then
         assertThat(count).isEqualTo(1);
+    }
+
+    @DisplayName("사용한 쿠폰 조회 - 성공")
+    @Test
+    void showUsedCoupon_success() {
+        // given
+        Product product = new Product(null, null, "product",
+            1000, 20, "", "", "", null);
+        Member member = new Member();
+        productRepository.save(product);
+        memberRepository.save(member);
+        Long coupon1 = couponService.createCoupon(new CouponRequestDto(
+            null, null, product.getId(),
+            "test", "COUPON",
+            LocalDateTime.of(2020, 3, 16, 3, 16),
+            LocalDateTime.of(2025, 3, 16, 3, 16),
+            null, 2000, 10000
+        ));
+
+        // when
+        couponService.downloadCoupon(coupon1, member.getId());
+        couponService.useCouponByMember(coupon1, member.getId());
+        List<Coupon> coupons = couponService.findUsedCoupons(member.getId());
+
+        // then
+        assertThat(coupons.size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## Resolve #213 

### 설명
- 사용한 쿠폰 조회 api 구현하였습니다.
- `MemberCoupon` 에서  `isUsed` 가 `true` 인 경우의 쿠폰만 List 로 반환하였습니다.

<img width="855" alt="image" src="https://user-images.githubusercontent.com/34434135/200717025-e941f55a-dc59-4bcf-a7ae-4facdf132490.png">


### 기타
- 테스트를 위해 회원이 쿠폰을 사용하는 경우의 api 도 추가하였는데 필요 없다고 판단되면 삭제하겠습니다.
