### PR TITLE
feat: 장바구니 쿠폰 검증 및 취소 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Spring Cloud Config
 backend/config-service/src/main/resources/application.yml
+backend/main-service/src/main/resources/static/product-data-v2.csv
+frontend/.next/
 
 ### Git ###
 # Created by git for backups. To disable backups in Git:

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -109,7 +109,6 @@ public class CartService {
 
         CartItem cartItem = cartItemRepository.findByIdandMemberId(cartItemId, loginMemberId).orElseThrow(KkaKkaException::new);
         Coupon coupon = couponRepository.findById(couponId).orElseThrow(KkaKkaException::new);
-        cartItem.getProduct().getDiscount()
         cartItem.applyCoupon(coupon);
         Integer discountedPrice = cartItem.getDiscountedPrice(coupon);
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -58,7 +58,7 @@ public class CartItem {
     }
 
     public Integer getDiscountedPrice(Coupon coupon) {
-        return product.getPrice() - product.getMaxDiscount(coupon);
+        return product.getDiscountPrice() - product.getMaxDiscount(coupon);
     }
 
     @Override

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -57,6 +57,12 @@ public class CartItem {
         this.coupon = coupon;
     }
 
+    public void cancelCoupon(Coupon coupon) {
+        if (coupon == this.coupon) {
+            this.coupon = null;
+        }
+    }
+
     public Integer getDiscountedPrice(Coupon coupon) {
         return product.getDiscountPrice() - product.getMaxDiscount(coupon);
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/CartController.java
@@ -48,8 +48,15 @@ public class CartController {
     public ResponseEntity<CartItemDto> applyCartCoupon(@PathVariable("cartItemId") Long cartItemId,
                                                        @PathVariable("couponId") Long couponId,
                                                        @AuthenticationPrincipal LoginMember loginMember) {
-        // TODO : 멤버 카트아이템 검증 추가
         CartItemDto cartItemDto = cartService.applyCouponCartItem(cartItemId, couponId, loginMember);
+        return ResponseEntity.status(HttpStatus.OK).body(cartItemDto);
+    }
+
+    @DeleteMapping("/{cartItemId}/{couponId}")
+    public ResponseEntity<CartItemDto> cancelCartCoupon(@PathVariable("cartItemId") Long cartItemId,
+                                                        @PathVariable("couponId") Long couponId,
+                                                        @AuthenticationPrincipal LoginMember loginMember) {
+        CartItemDto cartItemDto = cartService.cancelCouponCartItem(cartItemId, couponId, loginMember);
         return ResponseEntity.status(HttpStatus.OK).body(cartItemDto);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartItemDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/ui/dto/CartItemDto.java
@@ -22,25 +22,22 @@ public class CartItemDto {
     private Integer totalDiscount;
     private CouponDto couponDto;
 
-    public static CartItemDto from(CartItem c) {
+    public static CartItemDto createWithoutCoupon(CartItem c) {
+        return new CartItemDto(
+                c.getId(),
+                c.getProduct().getId(),
+                c.getProduct().getName(),
+                c.getProduct().getDiscount(),
+                c.getProduct().getImageUrl(),
+                c.getQuantity(),
+                c.getProduct().getPrice(),
+                c.getPrice(),
+                0,
+                0,
+                null);
+    }
 
-        Coupon coupon = c.getCoupon();
-        if (coupon == null) {
-            return new CartItemDto(
-                    c.getId(),
-                    c.getProduct().getId(),
-                    c.getProduct().getName(),
-                    c.getProduct().getDiscount(),
-                    c.getProduct().getImageUrl(),
-                    c.getQuantity(),
-                    c.getProduct().getPrice(),
-                    c.getPrice(),
-                    0,
-                    0,
-                    null);
-        }
-
-        Integer discountedPrice = c.getDiscountedPrice(coupon);
+    public static CartItemDto createWithCoupon(CartItem c, Integer discountedPrice, Coupon coupon) {
         return new CartItemDto(
                 c.getId(),
                 c.getProduct().getId(),
@@ -53,21 +50,6 @@ public class CartItemDto {
                 discountedPrice * c.getQuantity(),
                 c.getPrice() - (discountedPrice * c.getQuantity()),
                 CouponDto.toDto(coupon));
-    }
-
-    public static CartItemDto applyCouponDto(CartItem c, Integer discountedPrice, CouponDto couponDto) {
-        return new CartItemDto(
-                c.getId(),
-                c.getProduct().getId(),
-                c.getProduct().getName(),
-                c.getProduct().getDiscount(),
-                c.getProduct().getImageUrl(),
-                c.getQuantity(),
-                c.getProduct().getPrice(),
-                c.getPrice(),
-                discountedPrice * c.getQuantity(),
-                c.getPrice() - (discountedPrice * c.getQuantity()),
-                couponDto);
     }
 
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/MemberCoupon.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/domain/MemberCoupon.java
@@ -42,6 +42,10 @@ public class MemberCoupon {
         this.isUsed = true;
     }
 
+    public void cancelCoupon() {
+        this.isUsed = false;
+    }
+
     public boolean isUsed() {
         return this.isUsed;
     }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/Product.java
@@ -79,6 +79,10 @@ public class Product {
         this.ratingAvg = ratingAvg;
     }
 
+    public Integer getDiscountPrice() {
+        return (int)(price * (1 - discount * 0.01));
+    }
+
     public Integer getMaxDiscount(Coupon coupon) {
         Integer maxDiscount = coupon.getMaxDiscount();
 

--- a/backend/main-service/src/test/java/kkakka/mainservice/cart/ui/CartAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/cart/ui/CartAcceptanceTest.java
@@ -201,6 +201,30 @@ class CartAcceptanceTest extends DocumentConfiguration {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
+    @DisplayName("장바구니 쿠폰 적용 취소 성공")
+    @Test
+    void cancelCouponCartItem_success() {
+        //given
+        final String accessToken = 액세스_토큰_가져옴();
+        장바구니_추가함(accessToken, PRODUCT_1.getId(), 1);
+        장바구니_추가함(accessToken, PRODUCT_2.getId(), 1);
+        final CartResponseDto cart = 장바구니에서_찾아옴(accessToken);
+        퍼센트_쿠폰_생성();
+        장바구니_쿠폰_적용(cart.getCartItemDtos().get(0).getCartItemId(),1L,accessToken);
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given(spec).log().all()
+                .filter(document("cancelCartItemCoupon-success"))
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/api/carts/" + cart.getCartItemDtos().get(0).getCartItemId() + "/" + 1)
+                .then().log().all().extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
     @DisplayName("총 장바구니 아이템 수 조회 - 성공")
     @Test
     void findMemberCartItemCount_success(){


### PR DESCRIPTION
## Resolve #218 

### 설명
- 장바구니 조회시에 쿠폰이 적용된 곳이 있으면 유효기간을 검증하는 로직을 추가하였습니다.
- 유효기간이 지나지 않았더라도 쿠폰적용을 취소할 수 있는 기능을 추가하였습니다.

쿠폰적용과 동일하게 Post 대신 Delete 로 보내면 됩니다.
/api/cart/{cartItem_Id}/{coupon_Id}

