### PR TITLE
fix: DataLoader.categories 를 읽지 못하는 문제

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/DataLoader.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/DataLoader.java
@@ -39,7 +39,7 @@ public class DataLoader {
     private final ReviewRepository reviewRepository;
     private final NutritionRepository nutritionRepository;
 
-    private final Map<String, Category> categories = new LinkedHashMap<>();
+    public static final Map<String, Category> categories = new LinkedHashMap<>();
     private boolean categoryFlag = false;
     private Product testProduct;
     private Member testMember;

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.order.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kkakka.mainservice.order.domain.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
### 설명
- `DataLoader.categories` 를 외부에서 사용하고 있지만 `private` 으로 선언되어 오류가 발생하던 것을 해결했습니다.