### PR TITLE
fix: 상품 조회 페이지가 제대로 조회되지 않는 문제 해결

### DIFF
--- a/backend/main-service/src/docs/asciidoc/product.adoc
+++ b/backend/main-service/src/docs/asciidoc/product.adoc
@@ -24,6 +24,16 @@ include::{snippets}/products-show-all-success/http-request.adoc[]
 
 include::{snippets}/products-show-all-success/http-response.adoc[]
 
+=== 전체 상품 조회 (페이지)
+
+- Request
+
+include::{snippets}/products-show-all-page-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/products-show-all-page-success/http-response.adoc[]
+
 === 카테고리 기준 조회
 
 - Request

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package kkakka.mainservice.order.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import kkakka.mainservice.order.domain.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
@@ -3,6 +3,7 @@ package kkakka.mainservice.product.domain.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -13,9 +14,9 @@ import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.QProduct;
 import kkakka.mainservice.product.domain.SearchWords;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -57,7 +58,13 @@ public class ProductRepositorySupport extends QuerydslRepositorySupport {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(result, pageable, result.size());
+        final JPAQuery<Long> countQuery = queryFactory.select(QProduct.product.count())
+                .from(QProduct.product)
+                .where(
+                        builder
+                );
+
+        return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }
 
     private boolean isSavedCategoryId(Long cId) {

--- a/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestDataLoader.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestDataLoader.java
@@ -6,8 +6,8 @@ import java.util.List;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.member.member.domain.Member;
-import kkakka.mainservice.member.member.domain.ProviderName;
 import kkakka.mainservice.member.member.domain.Provider;
+import kkakka.mainservice.member.member.domain.ProviderName;
 import kkakka.mainservice.member.member.domain.repository.MemberRepository;
 import kkakka.mainservice.order.application.dto.RecipientDto;
 import kkakka.mainservice.order.domain.Order;
@@ -60,6 +60,7 @@ public class TestDataLoader implements CommandLineRunner {
     public static ProductOrder PRODUCT_ORDER_3;
     public static ProductOrder PRODUCT_ORDER_4;
     public static ProductOrder PRODUCT_ORDER_5;
+    public static List<Product> ALL_PRODUCTS;
 
     @Override
     public void run(String... args) {
@@ -107,6 +108,8 @@ public class TestDataLoader implements CommandLineRunner {
         PRODUCT_5 = productRepository.save(new Product(CATEGORY_2, "롯데 롯샌 파인애플 105g", 4480, 100,
                 "https://user-images.githubusercontent.com/99088509/191633507-6280963f-6363-4137-ac2a-a8a060d28669.png",
                 "상세URL", NUTRITION_5));
+
+        ALL_PRODUCTS = List.of(PRODUCT_1, PRODUCT_2, PRODUCT_3, PRODUCT_4, PRODUCT_5);
 
         PRODUCT_ORDER_1 = productOrderRepository.save(
                 ProductOrder.create(PRODUCT_1, PRODUCT_1.getPrice(), 1)

--- a/backend/main-service/src/test/java/kkakka/mainservice/product/acceptance/ProductAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/product/acceptance/ProductAcceptanceTest.java
@@ -8,7 +8,10 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import kkakka.mainservice.DocumentConfiguration;
+import kkakka.mainservice.fixture.TestDataLoader;
+import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.ui.dto.ProductResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -94,6 +97,33 @@ public class ProductAcceptanceTest extends DocumentConfiguration {
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("전체 상품 조회(2페이지 이상) - 성공")
+    void showAllProductsPage_success() {
+        //given
+        int pageSize = 3;
+        //when
+        ExtractableResponse<Response> response = RestAssured
+                .given(spec).log().all()
+                .filter(document("products-show-all-page-success"))
+                .when()
+                .get("/api/products?size=" + pageSize)
+                .then()
+                .log().all().extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().get("pageInfo.lastPage").toString())
+                .isEqualTo(String.valueOf(calculatePage(TestDataLoader.ALL_PRODUCTS, pageSize)));
+    }
+
+    private int calculatePage(List<Product> products, int pageSize) {
+        if (products.size() % pageSize > 0) {
+            return products.size() / pageSize + 1;
+        }
+        return products.size() / pageSize;
     }
 
     @DisplayName("검색 조회 - 성공")

--- a/backend/main-service/src/test/java/kkakka/mainservice/product/acceptance/ProductAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/product/acceptance/ProductAcceptanceTest.java
@@ -109,7 +109,7 @@ public class ProductAcceptanceTest extends DocumentConfiguration {
                 .given(spec).log().all()
                 .filter(document("products-show-all-page-success"))
                 .when()
-                .get("/api/products?size=" + pageSize)
+                .get("/api/products?page=1&size=" + pageSize)
                 .then()
                 .log().all().extract();
 


### PR DESCRIPTION
## Resolve #223 

### 설명
- 현재 페이지 외에 페이지 정보를 제대로 받아오지 못하는 문제를 수정했습니다.
- 참고하기 좋게 API 문서 쪽에 하나 더 추가했습니다.
![스크린샷 2022-11-10 오전 11 47 30](https://user-images.githubusercontent.com/52682603/200988287-2ff21475-5e2c-435c-80ab-7224d1948939.png)
- 페이지에 대한 API 가 바뀐 것은 아니고, 조회할 페이지와 사이즈를 요청에서 조절할 수 있습니다.