### PR TITLE
fix: 장바구니 비우기 기능 수정

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/application/CartService.java
@@ -108,8 +108,7 @@ public class CartService {
     @Transactional
     public void emptyCart(LoginMember loginMember) {
         try {
-            final Cart cart = cartRepository.findById(loginMember.getId())
-                    .orElseThrow();
+            final Cart cart = cartRepository.findByMemberId(loginMember.getId()).orElseThrow();
             cartItemRepository.deleteAllByMemberId(loginMember.getId());
             cart.empty();
         } catch (Exception e) {

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -47,6 +47,10 @@ public class Cart {
         return cartItems.isEmpty();
     }
 
+    public void empty() {
+        cartItems = new ArrayList<>();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartItemRepository.java
@@ -2,6 +2,7 @@ package kkakka.mainservice.cart.domain.repository;
 
 import kkakka.mainservice.cart.domain.CartItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,7 +16,8 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     @Query("select ci from CartItem ci join fetch ci.cart join ci.cart.member m where ci.id = :cartItemId and m.id = :memberId")
     Optional<CartItem> findByIdandMemberId(@Param("cartItemId") Long cartId, @Param("memberId") Long memberId);
 
-    @Query("delete from CartItem ci where ci.cart.member.id = :memberId")
+    @Modifying
+    @Query("delete from CartItem ci where ci.cart.id in (select c.id from ci.cart c where c.member.id = :memberId)")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 
     @Query("select count(ci) from CartItem ci where ci.cart.member.id = :memberId")

--- a/backend/main-service/src/test/java/kkakka/mainservice/cart/application/CartServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/cart/application/CartServiceTest.java
@@ -2,6 +2,7 @@ package kkakka.mainservice.cart.application;
 
 import static kkakka.mainservice.fixture.TestDataLoader.MEMBER;
 import static kkakka.mainservice.fixture.TestDataLoader.PRODUCT_1;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import kkakka.mainservice.TestContext;
 import kkakka.mainservice.cart.ui.dto.CartRequestDto;
@@ -29,12 +30,13 @@ public class CartServiceTest extends TestContext {
         LoginMember loginMember = new LoginMember(member.getId(), Authority.MEMBER);
 
         cartService.addCartItem(cartRequestDto, loginMember);
+        assertThat(cartService.showCartItemCount(loginMember.getId())).isEqualTo(1);
 
         // when
+        cartService.emptyCart(loginMember);
+
         // then
-        Assertions.assertThatCode(
-                () -> cartService.emptyCart(loginMember)
-        ).doesNotThrowAnyException();
+        assertThat(cartService.showCartItemCount(loginMember.getId())).isEqualTo(0);
     }
 
     @DisplayName("장바구니 비우기 - 실패(에러 없음)")

--- a/backend/main-service/src/test/java/kkakka/mainservice/cart/domain/CartRepositoryTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/cart/domain/CartRepositoryTest.java
@@ -9,8 +9,8 @@ import kkakka.mainservice.cart.domain.repository.CartRepository;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
 import kkakka.mainservice.member.member.domain.Member;
-import kkakka.mainservice.member.member.domain.ProviderName;
 import kkakka.mainservice.member.member.domain.Provider;
+import kkakka.mainservice.member.member.domain.ProviderName;
 import kkakka.mainservice.member.member.domain.repository.MemberRepository;
 import kkakka.mainservice.product.domain.Nutrition;
 import kkakka.mainservice.product.domain.Product;
@@ -120,5 +120,42 @@ public class CartRepositoryTest extends TestContext {
         savedItem.changeQuantity(3);
 
         assertThat(cart.getCartItems().get(0).getQuantity()).isEqualTo(3);
+    }
+
+    @DisplayName("장바구니에 담긴 아이템 삭제 테스트")
+    @Test
+    void deleteCartItemFromCart() {
+        // given
+        final Member member = memberRepository.save(
+                Member.create(
+                        Provider.create(TEST_MEMBER_01.getProviderId(), ProviderName.TEST),
+                        TEST_MEMBER_01.getName(),
+                        TEST_MEMBER_01.getEmail(),
+                        TEST_MEMBER_01.getPhone(),
+                        TEST_MEMBER_01.getAgeGroup()
+                )
+        );
+        final Product product = productRepository.save(
+                new Product(
+                        categoryRepository.save(new Category("test-category")),
+                        "product-name", 1000, 10, "", "",
+                        nutrition
+                )
+        );
+        final Cart cart = cartRepository.save(
+                new Cart(member)
+        );
+        final CartItem cartItem = CartItem.create(cart, product);
+        cartItem.changeQuantity(1);
+        cartItemRepository.save(cartItem);
+        cart.add(cartItem);
+
+        // when
+        cartItemRepository.deleteAllByMemberId(member.getId());
+        cart.empty();
+
+        // then
+        final Cart savedCart = cartRepository.findById(cart.getId()).get();
+        assertThat(savedCart.getCartItems().isEmpty()).isTrue();
     }
 }


### PR DESCRIPTION
## Resolve #170 

### 설명
- 주문이 완료된 뒤에 장바구니 비우기가 동작하지 않는 문제가 있어 해결했습니다.
- 영속성 접근 메서드를 수정하고, `Cart` 도메인에도 관련 로직을 추가했습니다.
- 좀 더 검증하기 쉽도록 테스트 코드를 추가했습니다.