### PR TITLE
feat: 검색 자동완성 기능 구현

### DIFF
--- a/backend/main-service/src/docs/asciidoc/product.adoc
+++ b/backend/main-service/src/docs/asciidoc/product.adoc
@@ -64,7 +64,7 @@ include::{snippets}/products-show-search/http-request.adoc[]
 
 include::{snippets}/products-show-search/http-response.adoc[]
 
-=== 자동 검색
+=== es 적용 검색
 
 - Request
 
@@ -73,3 +73,13 @@ include::{snippets}/show-products-search-success/http-request.adoc[]
 - Response
 
 include::{snippets}/show-products-search-success/http-response.adoc[]
+
+=== 자동 완성
+
+- Request
+
+include::{snippets}/show-product-names-search-autocomplete/http-request.adoc[]
+
+- Response
+
+include::{snippets}/show-product-names-search-autocomplete/http-response.adoc[]

--- a/backend/main-service/src/docs/asciidoc/product.adoc
+++ b/backend/main-service/src/docs/asciidoc/product.adoc
@@ -63,3 +63,13 @@ include::{snippets}/products-show-search/http-request.adoc[]
 - Response
 
 include::{snippets}/products-show-search/http-response.adoc[]
+
+=== 자동 검색
+
+- Request
+
+include::{snippets}/show-products-search-success/http-request.adoc[]
+
+- Response
+
+include::{snippets}/show-products-search-success/http-response.adoc[]

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/ProductDocumentService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/ProductDocumentService.java
@@ -36,4 +36,8 @@ public class ProductDocumentService {
             productDtos,
             searchResult.getPageInfo()).toResponseDto();
     }
+
+    public List<String> autoCompleteByKeyword(String keyword) {
+        return searchHelper.autoCompleteByKeyword(keyword);
+    }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/SearchHelper.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/SearchHelper.java
@@ -8,5 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface SearchHelper {
 
     ProductsSearchResult searchProductIds(SearchParamDto searchParamDto, Pageable pageable);
+
     List<String> autoCompleteByKeyword(String keyword);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/SearchHelper.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/SearchHelper.java
@@ -1,5 +1,6 @@
 package kkakka.mainservice.elasticsearch.application;
 
+import java.util.List;
 import kkakka.mainservice.elasticsearch.application.dto.SearchParamDto;
 import kkakka.mainservice.elasticsearch.helper.ProductsSearchResult;
 import org.springframework.data.domain.Pageable;
@@ -7,4 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface SearchHelper {
 
     ProductsSearchResult searchProductIds(SearchParamDto searchParamDto, Pageable pageable);
+    List<String> autoCompleteByKeyword(String keyword);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/dto/SearchParamDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/application/dto/SearchParamDto.java
@@ -1,6 +1,5 @@
 package kkakka.mainservice.elasticsearch.application.dto;
 
-import java.net.URI;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/domain/repository/ProductDocumentQueryBuilder.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/domain/repository/ProductDocumentQueryBuilder.java
@@ -45,6 +45,13 @@ public class ProductDocumentQueryBuilder {
         return query.withPageable(pageable).build();
     }
 
+    public Query autoCompleteByKeyword(String keyword) {
+        NativeSearchQueryBuilder query = new NativeSearchQueryBuilder();
+
+        return query.withQuery(QueryBuilders.boolQuery()
+            .must(QueryBuilders.queryStringQuery(keyword))).build();
+    }
+
     private static TermsQueryBuilder selectFilter(String field, List<Long> query) {
         return ((Optional.ofNullable(query).isEmpty()) || query.size() == 0) ? null
             : QueryBuilders.termsQuery(field, query);

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/domain/repository/ProductDocumentQueryBuilder.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/domain/repository/ProductDocumentQueryBuilder.java
@@ -1,11 +1,9 @@
 package kkakka.mainservice.elasticsearch.domain.repository;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import kkakka.mainservice.elasticsearch.application.dto.SearchParamDto;
 import lombok.NoArgsConstructor;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/helper/ElasticSearchHelper.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/helper/ElasticSearchHelper.java
@@ -71,11 +71,9 @@ public class ElasticSearchHelper implements SearchHelper {
         SearchHits<ProductDocument> searchHits = elasticsearchRestTemplate.search(query,
             ProductDocument.class, IndexCoordinates.of(Indices.PRDUCT_INDEX));
 
-        List<String> productNames = searchHits.stream()
+        return searchHits.stream()
             .map(productDocumentSearchHit -> productDocumentSearchHit.getContent().getName())
             .collect(toList());
-
-        return productNames;
     }
 
     private PageInfo createPageInfo(SearchPage<ProductDocument> searchPages) {

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/helper/ElasticSearchHelper.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/helper/ElasticSearchHelper.java
@@ -43,7 +43,9 @@ public class ElasticSearchHelper implements SearchHelper {
         if (!searchHits.hasSearchHits()) {
             return new ProductsSearchResult(
                 new ArrayList<>(),
-                new PageInfo(),
+                PageInfo.from(
+                    pageable.getPageNumber(),0,pageable.getPageSize(),0
+                ),
                 searchHits.getTotalHits()
             );
         }

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/helper/ElasticSearchHelper.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/helper/ElasticSearchHelper.java
@@ -64,6 +64,20 @@ public class ElasticSearchHelper implements SearchHelper {
         );
     }
 
+    @Override
+    public List<String> autoCompleteByKeyword(String keyword) {
+        Query query = productDocumentQueryBuilder.autoCompleteByKeyword(keyword);
+
+        SearchHits<ProductDocument> searchHits = elasticsearchRestTemplate.search(query,
+            ProductDocument.class, IndexCoordinates.of(Indices.PRDUCT_INDEX));
+
+        List<String> productNames = searchHits.stream()
+            .map(productDocumentSearchHit -> productDocumentSearchHit.getContent().getName())
+            .collect(toList());
+
+        return productNames;
+    }
+
     private PageInfo createPageInfo(SearchPage<ProductDocument> searchPages) {
         return PageInfo.from(
             searchPages.getPageable().getPageNumber(),

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/ui/ProductDocumentController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/ui/ProductDocumentController.java
@@ -28,7 +28,6 @@ public class ProductDocumentController {
     public ResponseEntity<SearchResultResponse> showProductsBySearch(
         @ModelAttribute SearchParamRequest searchParamRequest,
         @PageableDefault(size = 9) Pageable pageable) {
-
         SearchResultResponse result = productDocumentService.findByKeyword(
             searchParamRequest.toDto(),
             pageable

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/ui/ProductDocumentController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/ui/ProductDocumentController.java
@@ -1,5 +1,8 @@
 package kkakka.mainservice.elasticsearch.ui;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import kkakka.mainservice.elasticsearch.application.ProductDocumentService;
 import kkakka.mainservice.elasticsearch.ui.dto.SearchParamRequest;
 import kkakka.mainservice.elasticsearch.ui.dto.SearchResultResponse;
@@ -11,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -31,5 +35,14 @@ public class ProductDocumentController {
         );
 
         return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @GetMapping("/auto")
+    public ResponseEntity<Map<String, List<String>>> autoCompleteByKeyword(@RequestParam(value = "keyword", required = false) String keyword) {
+        List<String> autoProductNames = productDocumentService.autoCompleteByKeyword(keyword);
+        Map<String, List<String>> result = new HashMap<>();
+        result.put("autoKeyword",autoProductNames);
+
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/ui/dto/SearchParamRequest.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/elasticsearch/ui/dto/SearchParamRequest.java
@@ -1,6 +1,5 @@
 package kkakka.mainservice.elasticsearch.ui.dto;
 
-import java.net.URI;
 import java.util.List;
 import kkakka.mainservice.elasticsearch.application.dto.SearchParamDto;
 import lombok.AllArgsConstructor;

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
@@ -24,5 +24,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     countQuery = "select count(p) from Product p where p.name like %:keyword% or p.category.name like %:keyword%")
     Page<Product> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
-
+    @Query("select p from Product p where p.name like %:keyword%")
+    List<Product> findTop10ByKeyword(@Param("keyword") String keyword);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepository.java
@@ -23,7 +23,4 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query(value = "select p from Product p where p.name like %:keyword% or p.category.name like %:keyword%",
     countQuery = "select count(p) from Product p where p.name like %:keyword% or p.category.name like %:keyword%")
     Page<Product> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
-
-    @Query("select p from Product p where p.name like %:keyword%")
-    List<Product> findTop10ByKeyword(@Param("keyword") String keyword);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
@@ -1,9 +1,6 @@
 package kkakka.mainservice.product.domain.repository;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import kkakka.mainservice.category.domain.QCategory;
@@ -41,11 +38,10 @@ public class ProductRepositorySupport extends QuerydslRepositorySupport {
         return new PageImpl<>(result, pageable, result.size());
     }
 
-    public List<Product> findTop10ByKeyword(String keyword) {
+    public List<Product> findTopNByKeyword(String keyword) {
         return queryFactory.selectFrom(QProduct.product)
             .where(QProduct.product.name.contains(keyword))
             .limit(10).fetch();
-
     }
 
     private BooleanBuilder categoryNameEq(SearchWords searchWords) {

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
@@ -3,6 +3,7 @@ package kkakka.mainservice.product.domain.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import kkakka.mainservice.category.domain.QCategory;
@@ -38,6 +39,13 @@ public class ProductRepositorySupport extends QuerydslRepositorySupport {
                 .fetch();
 
         return new PageImpl<>(result, pageable, result.size());
+    }
+
+    public List<Product> findTop10ByKeyword(String keyword) {
+        return queryFactory.selectFrom(QProduct.product)
+            .where(QProduct.product.name.contains(keyword))
+            .limit(10).fetch();
+
     }
 
     private BooleanBuilder categoryNameEq(SearchWords searchWords) {

--- a/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/acceptance/ProductDocumentAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/acceptance/ProductDocumentAcceptanceTest.java
@@ -10,7 +10,6 @@ import kkakka.mainservice.DocumentConfiguration;
 import kkakka.mainservice.elasticsearch.application.dto.ProductDocumentDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.internal.matchers.LessThan;
 import org.springframework.http.HttpStatus;
 
 public class ProductDocumentAcceptanceTest extends DocumentConfiguration {
@@ -57,5 +56,4 @@ public class ProductDocumentAcceptanceTest extends DocumentConfiguration {
             .map(name -> name.contains("롯데")))
             .isNotEmpty();
     }
-
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/acceptance/ProductDocumentAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/acceptance/ProductDocumentAcceptanceTest.java
@@ -10,6 +10,7 @@ import kkakka.mainservice.DocumentConfiguration;
 import kkakka.mainservice.elasticsearch.application.dto.ProductDocumentDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.internal.matchers.LessThan;
 import org.springframework.http.HttpStatus;
 
 public class ProductDocumentAcceptanceTest extends DocumentConfiguration {
@@ -33,6 +34,27 @@ public class ProductDocumentAcceptanceTest extends DocumentConfiguration {
         assertThat(response.body().jsonPath().getList("data",ProductDocumentDto.class).stream()
                             .map(productDocumentDto -> productDocumentDto.getName().contains("웨하스"))
                             .findAny())
+            .isNotEmpty();
+    }
+
+    @DisplayName("자동 완성 조회 - 성공")
+    @Test
+    void showAutoCompleteByKeyword_success() {
+        //given
+        //when
+        ExtractableResponse<Response> response = RestAssured
+            .given(spec).log().all()
+            .filter(document("show-product-names-search-autocomplete"))
+            .when()
+            .get("/api/es/auto?keyword=롯데")
+            .then()
+            .log().all().extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.body().jsonPath().getList("autoKeyword",String.class).size()).isLessThanOrEqualTo(10);
+        assertThat(response.body().jsonPath().getList("autoKeyword",String.class).stream()
+            .map(name -> name.contains("롯데")))
             .isNotEmpty();
     }
 

--- a/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/application/ProductDocumentServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/application/ProductDocumentServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Stream;
 import kkakka.mainservice.TestContext;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;

--- a/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/application/ProductDocumentServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/elasticsearch/application/ProductDocumentServiceTest.java
@@ -3,6 +3,8 @@ package kkakka.mainservice.elasticsearch.application;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
 import kkakka.mainservice.TestContext;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.repository.CategoryRepository;
@@ -62,4 +64,16 @@ public class ProductDocumentServiceTest extends TestContext {
         assertThat(response.getTotalHits()).isEqualTo(1);
     }
 
+    @DisplayName("ES 자동완성 조회 - 성공")
+    @Test
+    public void showAutoCompleteByKeywordTest() {
+        //given
+        final String keyword = "테스";
+
+        //when
+        List<String> response = productDocumentService.autoCompleteByKeyword(keyword);
+
+        //then
+        assertThat(response.get(0)).isEqualTo("롯데 테스트 과자 100g");
+    }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestSearchHelper.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestSearchHelper.java
@@ -1,11 +1,15 @@
 package kkakka.mainservice.fixture;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
 import kkakka.mainservice.common.dto.PageInfo;
 import kkakka.mainservice.elasticsearch.application.SearchHelper;
 import kkakka.mainservice.elasticsearch.application.dto.SearchParamDto;
 import kkakka.mainservice.elasticsearch.helper.ProductsSearchResult;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
+import kkakka.mainservice.product.domain.repository.ProductRepositorySupport;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,9 +20,12 @@ import org.springframework.stereotype.Component;
 public class TestSearchHelper implements SearchHelper {
 
     private final ProductRepository productRepository;
+    private final ProductRepositorySupport productRepositorySupport;
 
-    public TestSearchHelper(ProductRepository productRepository) {
+    public TestSearchHelper(ProductRepository productRepository,
+        ProductRepositorySupport productRepositorySupport) {
         this.productRepository = productRepository;
+        this.productRepositorySupport = productRepositorySupport;
     }
 
     @Override
@@ -32,5 +39,14 @@ public class TestSearchHelper implements SearchHelper {
             products.getTotalElements());
 
         return new ProductsSearchResult(products.getContent(),pageInfo,products.getTotalElements());
+    }
+
+    @Override
+    public List<String> autoCompleteByKeyword(String keyword) {
+        List<Product> products = productRepositorySupport.findTop10ByKeyword(keyword);
+
+        return products.stream()
+            .map(product -> product.getName())
+            .collect(toList());
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestSearchHelper.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/fixture/TestSearchHelper.java
@@ -43,7 +43,7 @@ public class TestSearchHelper implements SearchHelper {
 
     @Override
     public List<String> autoCompleteByKeyword(String keyword) {
-        List<Product> products = productRepositorySupport.findTop10ByKeyword(keyword);
+        List<Product> products = productRepositorySupport.findTopNByKeyword(keyword);
 
         return products.stream()
             .map(product -> product.getName())

--- a/frontend/apis/AutoComplete.js
+++ b/frontend/apis/AutoComplete.js
@@ -1,0 +1,42 @@
+import axios from "axios";
+
+export const fetchAutoData = (keyword) => {
+    const pPromise = getProductNames(keyword);
+    return {
+      ProductNames: wrapPromise(pPromise),
+    };
+  };
+
+  const getProductNames = (keyword) => {
+    return axios
+    .get(`/api/es/auto?keyword=${keyword}`)
+    .then((res) => res.data)
+    .catch((err) => console.log(err));
+  };
+  
+  const wrapPromise = (promise) => {
+    let status = "pending";
+    let result;
+    let suspender = promise.then(
+      (res) => {
+        status = "success";
+        result = res;
+      },
+      (err) => {
+        status = "error";
+        result = err;
+      },
+    );
+  
+    return {
+      read() {
+        if (status === "pending") {
+          throw suspender;
+        } else if (status === "error") {
+          throw result;
+        } else if (status === "success") {
+          return result;
+        }
+      },
+    };
+  };

--- a/frontend/components/common/HeaderComp.js
+++ b/frontend/components/common/HeaderComp.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import SearchBar from "./SearchBar";
-import { useContext } from "react";
+import { useContext, useRef } from "react";
 import { useEffect, useState } from "react";
 import { TokenContext } from "../../context/TokenContext";
 import { isLogin } from "../../hooks/isLogin";
@@ -15,39 +15,13 @@ export default function Header() {
   const [login, setLogin] = useState(false);
   const { token, setToken } = useContext(TokenContext);
 
+
   const getMemberInfo = async () => {
     await memberInfo(getToken()).then((res) => {
       setName(res.name);
     });
   };
 
-  const updateChange = (e) => {
-      if (isText(e.currentTarget.value)) {
-        setValue(e.currentTarget.value);
-      } else {
-        alert("특수문자는 입력할 수 없습니다.");
-        e.currentTarget.value = "";
-      }
-  }
-
-  function search(event) {
-    if (event.key === "Enter") {
-      if (value.length < 2 || value.length > 20) {
-        alert("두 글자 이상 스무 글자 이하로 입력하세요.");
-        return;
-      }
-
-      router.push(
-        {
-          pathname: `/product`,
-          query: { cat_id: 0, search: value },
-        },
-        `/product`,
-      );
-      setValue("");
-    }
-  }
-  
   useEffect(() => {
     if (isLogin()) {
       setToken(getToken());
@@ -55,12 +29,6 @@ export default function Header() {
       getMemberInfo();
     }
   }, [isLogin()]);
-
-  useEffect(() => {
-    if(value) {
-
-    }
-  },[value]);
 
   return (
     <div>
@@ -72,24 +40,17 @@ export default function Header() {
             </a>
           </Link>
         </div>
-        <div className="searchWrapper">
-          <div className="search">
-            <input
-              type="text"
-              size="30"
-              defaultValue={value}
-              placeholder="검색어를 입력해주세요"
-              onChange={(e) => updateChange(e)}
-              onKeyUp={(event) => {
-                search(event, value);
-              }}   
-            ></input>
-              {value.length > 0? <SearchBar value={value}/> : ""}
-            </div>
-              <Link href={`/product?search=${value}`}>
+        {/* <div className="searchWrapper"> */}
+          {/* <div className="search"> */}
+            <SearchBar value={value} setValue={setValue} />
+
+            {/* <Link href={`/product?search=${value}`}>
               <img src="/common/main_search.png" />
-            </Link>
-          </div>
+            </Link> */}
+
+
+          {/* </div> */}
+        {/* </div> */}
         <div className="icons">
           <div className="top">
             {login ? (
@@ -165,11 +126,12 @@ export default function Header() {
               transform: translate(-50%, -50%);
             }
           }
-          .searchWrapper {
+          /* .searchWrapper {
             position: absolute;
-            transform: translate(-50%, -50%);
-          }
+            transform: translate(-50%, 0%);
+          } */
           .search {
+            background: #fff;
             border: 2px solid #ed1b23;
 
             input[type="text"] {
@@ -236,7 +198,7 @@ export default function Header() {
               top: 35%;
             }
             .search {
-              border-radius: 40px;
+              border-radius: 15px;
               padding: 0 17px;
 
               input[type="text"] {

--- a/frontend/components/common/HeaderComp.js
+++ b/frontend/components/common/HeaderComp.js
@@ -6,8 +6,6 @@ import { TokenContext } from "../../context/TokenContext";
 import { isLogin } from "../../hooks/isLogin";
 import { getToken } from "../../hooks/getToken";
 import { memberInfo } from "../../hooks/memberInfo";
-import { isText } from "../../hooks/isText";
-import { router } from "next/router";
 
 export default function Header() {
   const [value, setValue] = useState("");
@@ -40,17 +38,7 @@ export default function Header() {
             </a>
           </Link>
         </div>
-        {/* <div className="searchWrapper"> */}
-          {/* <div className="search"> */}
-            <SearchBar value={value} setValue={setValue} />
-
-            {/* <Link href={`/product?search=${value}`}>
-              <img src="/common/main_search.png" />
-            </Link> */}
-
-
-          {/* </div> */}
-        {/* </div> */}
+        <SearchBar value={value} setValue={setValue} />
         <div className="icons">
           <div className="top">
             {login ? (

--- a/frontend/components/common/HeaderComp.js
+++ b/frontend/components/common/HeaderComp.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import SearchBar from "./SearchBar";
 import { useContext } from "react";
 import { useEffect, useState } from "react";
 import { TokenContext } from "../../context/TokenContext";
@@ -20,6 +21,15 @@ export default function Header() {
     });
   };
 
+  const updateChange = (e) => {
+      if (isText(e.currentTarget.value)) {
+        setValue(e.currentTarget.value);
+      } else {
+        alert("특수문자는 입력할 수 없습니다.");
+        e.currentTarget.value = "";
+      }
+  }
+
   function search(event) {
     if (event.key === "Enter") {
       if (value.length < 2 || value.length > 20) {
@@ -37,7 +47,7 @@ export default function Header() {
       setValue("");
     }
   }
-
+  
   useEffect(() => {
     if (isLogin()) {
       setToken(getToken());
@@ -45,6 +55,12 @@ export default function Header() {
       getMemberInfo();
     }
   }, [isLogin()]);
+
+  useEffect(() => {
+    if(value) {
+
+    }
+  },[value]);
 
   return (
     <div>
@@ -56,29 +72,24 @@ export default function Header() {
             </a>
           </Link>
         </div>
-        <div className="search">
-          <input
-            type="text"
-            size="30"
-            defaultValue={value}
-            placeholder="검색어를 입력해주세요"
-            onChange={(e) => {
-              if (isText(e.currentTarget.value)) {
-                setValue(e.currentTarget.value);
-              } else {
-                alert("특수문자는 입력할 수 없습니다.");
-                e.currentTarget.value = "";
-              }
-            }}
-            onKeyUp={(event) => {
-              search(event, value);
-            }}
-          ></input>
-
-          <Link href={`/product?search=${value}`}>
-            <img src="/common/main_search.png" />
-          </Link>
-        </div>
+        <div className="searchWrapper">
+          <div className="search">
+            <input
+              type="text"
+              size="30"
+              defaultValue={value}
+              placeholder="검색어를 입력해주세요"
+              onChange={(e) => updateChange(e)}
+              onKeyUp={(event) => {
+                search(event, value);
+              }}   
+            ></input>
+              {value.length > 0? <SearchBar value={value}/> : ""}
+            </div>
+              <Link href={`/product?search=${value}`}>
+              <img src="/common/main_search.png" />
+            </Link>
+          </div>
         <div className="icons">
           <div className="top">
             {login ? (
@@ -154,10 +165,11 @@ export default function Header() {
               transform: translate(-50%, -50%);
             }
           }
-
-          .search {
+          .searchWrapper {
             position: absolute;
             transform: translate(-50%, -50%);
+          }
+          .search {
             border: 2px solid #ed1b23;
 
             input[type="text"] {
@@ -219,9 +231,11 @@ export default function Header() {
               }
             }
 
-            .search {
+            .searchWrapper {
               left: 45%;
               top: 35%;
+            }
+            .search {
               border-radius: 40px;
               padding: 0 17px;
 

--- a/frontend/components/common/SearchBar.js
+++ b/frontend/components/common/SearchBar.js
@@ -1,0 +1,92 @@
+import { Search } from "@mui/icons-material";
+import Link from "next/link";
+import { router } from "next/router";
+import { useEffect } from "react";
+import { useState } from "react";
+import { fetchAutoData } from "../../apis/AutoComplete";
+
+export default function SearchBar({value}) {
+    const [keyword, setKeyword] = useState();
+    const [resource, setResource] = useState();
+
+    // function search(event) {
+    //     router.push(
+    //     {
+    //         pathname: `/product`,
+    //         query: { cat_id: 0, search: value },
+    //     },
+    //     `/product`,
+    //     );
+    //     //   setValue("");
+    // }
+  
+    useEffect(() => {
+        setKeyword(value);
+        autoComplete();
+    }, [value]);
+    
+    const autoComplete = async () => {
+        console.log("first ",keyword);
+        setResource(fetchAutoData(keyword));
+    }
+
+    if(!keyword) return;
+
+    const data = resource.ProductNames.read();
+
+        return (
+            <>
+                {<ul className="abs bk" onKeyDown={e => {console.log("keydown")}}>
+                    {data.autoKeyword.length > 0 ? 
+                    data?.autoKeyword?.map((productName) => {
+                        return (
+                            productName.includes(keyword) ?
+                                <li className="autoName" onClick={(e) => Search(e)}>
+                                    {productName.split(keyword)[0]}
+                                    <span className="boldName">{keyword}</span>
+                                    {productName.split(keyword)[1]}
+                                </li>  
+                                : <li className="autoName" onClick={(e) => Search(e)}>{productName}</li>
+                                )
+                            })
+                        : <li className="autoName">최근 검색결과가 없습니다.</li>}
+                 </ul>}
+
+                <style jsx>{`
+                    @media screen and (min-width: 769px) {
+                     /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
+                     .abs {
+                        position: absolute;
+                     }
+
+                     .bk {
+                        /* background: #fff; */
+                        background: #eee;
+                        width: 317px;
+                        margin: 0;
+                        padding: 10px;
+                     }
+
+                     .autoName {
+                        list-style: none;
+                     }
+
+                     .autoName:hover {
+                        background: #1a1a1a;
+                     }
+
+                     .boldName {
+                            color:#ed1b23; 
+                            font-weight:bold;
+                        }
+
+                    }
+
+                    @media screen and (max-width: 768px) {
+                    /* 태블릿에 사용될 스트일 시트를 여기에 작성합니다. */
+                    }
+                `}
+                </style>  
+            </>
+        );
+    };

--- a/frontend/components/common/SearchBar.js
+++ b/frontend/components/common/SearchBar.js
@@ -1,92 +1,232 @@
 import { Search } from "@mui/icons-material";
 import Link from "next/link";
 import { router } from "next/router";
-import { useEffect } from "react";
+import { forwardRef, useEffect } from "react";
+import { useRef } from "react";
 import { useState } from "react";
 import { fetchAutoData } from "../../apis/AutoComplete";
+import { isText } from "../../hooks/isText";
 
-export default function SearchBar({value}) {
+export default function SearchBar({ value, setValue }) {
     const [keyword, setKeyword] = useState();
     const [resource, setResource] = useState();
 
-    // function search(event) {
-    //     router.push(
-    //     {
-    //         pathname: `/product`,
-    //         query: { cat_id: 0, search: value },
-    //     },
-    //     `/product`,
-    //     );
-    //     //   setValue("");
-    // }
-  
-    useEffect(() => {
-        setKeyword(value);
-        autoComplete();
-    }, [value]);
-    
-    const autoComplete = async () => {
-        console.log("first ",keyword);
-        setResource(fetchAutoData(keyword));
+    const [index, setIndex] = useState(-1);
+    const autoRef = useRef(null);
+
+    const onChangeData = (e) => {
+        console.log("change ", keyword);
+        setKeyword(e.currentTarget.value);
+    };
+    const handleKeyArrow = (e) => {
+        // console.log("autoRef", autoRef.current.childElementCount, index);
+        if (data.autoKeyword.length > 0) {
+            switch (e.key) {
+                case "ArrowDown":
+                    setIndex(index + 1);
+                    if (autoRef.current?.childElementCount === index + 1) setIndex(0);
+                    break;
+                case "ArrowUp":
+                    setIndex(index - 1);
+                    if (index <= 0) {
+                        setIndex(-1);
+                    }
+                    break;
+                case "Escape":
+                    setIndex(-1);
+                    break;
+            }
+        }
     }
 
-    if(!keyword) return;
+    useEffect(() => {
+        autoComplete();
+    }, [keyword]);
 
-    const data = resource.ProductNames.read();
+    const updateChange = (e) => {
+        if (isText(e.currentTarget.value)) {
+            setValue(e.currentTarget.value);
+        } else {
+            alert("특수문자는 입력할 수 없습니다.");
+            e.currentTarget.value = "";
+        }
+    }
 
-        return (
-            <>
-                {<ul className="abs bk" onKeyDown={e => {console.log("keydown")}}>
-                    {data.autoKeyword.length > 0 ? 
-                    data?.autoKeyword?.map((productName) => {
-                        return (
-                            productName.includes(keyword) ?
-                                <li className="autoName" onClick={(e) => Search(e)}>
-                                    {productName.split(keyword)[0]}
-                                    <span className="boldName">{keyword}</span>
-                                    {productName.split(keyword)[1]}
-                                </li>  
-                                : <li className="autoName" onClick={(e) => Search(e)}>{productName}</li>
-                                )
-                            })
-                        : <li className="autoName">최근 검색결과가 없습니다.</li>}
-                 </ul>}
+    function search(event) {
+        if (event.key === "Enter") {
+            if (value.length < 2 || value.length > 20) {
+                alert("두 글자 이상 스무 글자 이하로 입력하세요.");
+                return;
+            }
 
-                <style jsx>{`
-                    @media screen and (min-width: 769px) {
-                     /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
-                     .abs {
-                        position: absolute;
-                     }
+            console.log("currunt :", event.currentTarget);
+            console.log("event: ", value);
+            router.push(
+                {
+                    pathname: `/product`,
+                    query: { cat_id: 0, search: value },
+                },
+                `/product`,
+            );
+            // setValue("");
+        }
+    }
 
-                     .bk {
-                        /* background: #fff; */
-                        background: #eee;
+    function keypress(event) {
+        console.log("keypress: ", event.keyCode);
+        if (event.keyCode == 40) {
+            console.log("아래");
+            console.log("target ", inputRef.current);
+        }
+    }
+
+    const autoComplete = async () => {
+        // console.log("auto ",ref.current);
+        if (keyword)
+            setResource(fetchAutoData(keyword));
+    }
+
+    function searchClick(event, name) {
+        setKeyword();
+        router.push(
+            {
+                pathname: `/product`,
+                query: { cat_id: 0, search: name },
+            },
+            `/product`,
+        );
+        // setValue("");
+    }
+
+    const data = resource?.ProductNames.read();
+
+    return (
+        <>
+            {console.log("keyword ", keyword.length)}
+            <div className="searchWrapper">
+                <div className="search">
+                    <input
+                        type="text"
+                        size="30"
+                        defaultValue={value}
+                        placeholder="검색어를 입력해주세요"
+                        onChange={(e) => onChangeData(e)}
+                        onKeyUp={(event) => {
+                            search(event, keyword);
+                        }}
+                        onKeyDown={(e) => handleKeyArrow(e)} />
+                    <Link href={`/product?search=${keyword}`}>
+                        <img src="/common/main_search.png" />
+                    </Link>
+                    {keyword.length > 0 ?
+                        <ul className="abs bk" ref={autoRef}>
+                            {data?.autoKeyword.length > 0 ?
+                                data?.autoKeyword?.map((productName, idx) => {
+                                    return (
+                                        productName.includes(keyword) ?
+                                            <li className={index === idx ? "autoName isFocus" : "autoName"} onKeyDown={(e) => keypress(e, productName)} onClick={(e) => search(e, productName)}>
+                                                <div className="name">
+                                                    {productName.split(keyword)[0]}
+                                                    <span className="boldName">{keyword}</span>
+                                                    {productName.split(keyword)[1]}
+                                                </div>
+                                            </li>
+                                            : <li className="autoName" onClick={(e) => searchClick(e)}><div className="name">{productName}</div></li>
+                                    )
+                                })
+                                : <li className="autoName">최근 검색결과가 없습니다.</li>}
+                        </ul> : ""
+                    }
+                    <style jsx>{`
+                .search {
+                    position: absolute;
+                    transform: translate(95%, 0%);
+                    background: #fff;
+                    border: 2px solid #ed1b23;
+
+                    input[type="text"] {
+                    border: none;
+                    padding: 0;
+                    box-sizing: border-box;
+                    color: #c5c9cd;
+                    font-weight: 600;
+                    }
+
+                    input[type="text"]:focus {
+                    outline: none;
+                    color: #000;
+                    }
+
+                    img {
+                    position: relative;
+                    }
+                }
+                        .isFocus{
+                            background: #e5e5e5;
+                            cursor: pointer;
+                        }
+                        .bk {
+                        /* border: 1px solid #ed1b23; */
                         width: 317px;
                         margin: 0;
-                        padding: 10px;
-                     }
-
-                     .autoName {
-                        list-style: none;
-                     }
-
-                     .autoName:hover {
-                        background: #1a1a1a;
-                     }
-
-                     .boldName {
-                            color:#ed1b23; 
-                            font-weight:bold;
+                        padding: 0px;
                         }
 
-                    }
+                        .contour {
+                        border: 1px solid #ed1b23;
+                        }
 
-                    @media screen and (max-width: 768px) {
-                    /* 태블릿에 사용될 스트일 시트를 여기에 작성합니다. */
+                        .name {
+                        padding: 2px 0px;
+                        }
+
+                        .autoName {
+                        list-style: none;
+                        }
+
+                        .autoName:hover {
+                        background: #e5e5e5;
+                        cursor: pointer;
+                        }
+
+                        .boldName {
+                            color:#ed1b23; 
+                            font-weight:bold;
                     }
-                `}
-                </style>  
-            </>
-        );
-    };
+                                @media screen and (min-width: 769px) {
+                                /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
+                                .searchWrapper {
+                        left: 45%;
+                        top: 35%;
+                        }
+                        .search {
+                        border-radius: 15px;
+                        padding: 0 17px;
+
+                        input[type="text"] {
+                            border-radius: 40px;
+                            width: 317px;
+                            height: 45px;
+                            line-height: 45px;
+                            font-size: 1em;
+                        }
+
+                        img {
+                            width: 24px;
+                            height: 24px;
+                            top: 5px;
+                        }
+                        }
+
+                                }
+
+                                @media screen and (max-width: 768px) {
+                                /* 태블릿에 사용될 스트일 시트를 여기에 작성합니다. */
+                                }
+                            `}
+                    </style>
+                </div>
+            </div>
+        </>
+    );
+};

--- a/frontend/components/common/SearchBar.js
+++ b/frontend/components/common/SearchBar.js
@@ -1,25 +1,27 @@
 import { Search } from "@mui/icons-material";
 import Link from "next/link";
 import { router } from "next/router";
-import { forwardRef, useEffect } from "react";
+import { useEffect } from "react";
 import { useRef } from "react";
 import { useState } from "react";
 import { fetchAutoData } from "../../apis/AutoComplete";
-import { isText } from "../../hooks/isText";
 
 export default function SearchBar({ value, setValue }) {
     const [keyword, setKeyword] = useState();
     const [resource, setResource] = useState();
 
     const [index, setIndex] = useState(-1);
+    const [over, setOver] = useState(false);
     const autoRef = useRef(null);
+    const inputRef = useRef(null);
 
     const onChangeData = (e) => {
-        console.log("change ", keyword);
         setKeyword(e.currentTarget.value);
     };
+
     const handleKeyArrow = (e) => {
-        // console.log("autoRef", autoRef.current.childElementCount, index);
+        if (!data) return;
+
         if (data.autoKeyword.length > 0) {
             switch (e.key) {
                 case "ArrowDown":
@@ -35,6 +37,15 @@ export default function SearchBar({ value, setValue }) {
                 case "Escape":
                     setIndex(-1);
                     break;
+                case "Enter":
+                    if (index === -1) break;
+                    var inputKeyword = autoRef.current.childNodes[index].childNodes[0].innerText;
+                    setKeyword(inputKeyword);
+                    inputRef.current.value = inputKeyword;
+                    searchClick(inputKeyword);
+                    break;
+                default:
+                    setIndex(-1);
             }
         }
     }
@@ -43,51 +54,57 @@ export default function SearchBar({ value, setValue }) {
         autoComplete();
     }, [keyword]);
 
-    const updateChange = (e) => {
-        if (isText(e.currentTarget.value)) {
-            setValue(e.currentTarget.value);
-        } else {
-            alert("특수문자는 입력할 수 없습니다.");
-            e.currentTarget.value = "";
+    useEffect(() => {
+        function handleOutside(e) {
+            if (autoRef.current && !autoRef.current.contains(e.target)) {
+                setOver(false);
+                setIndex(-1);
+                console.log("over ", over);
+            }
         }
-    }
+        document.addEventListener("mousedown", handleOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleOutside);
+        };
+    }, [autoRef]);
+
+    // const updateChange = (e) => {
+    //     if (isText(e.currentTarget.value)) {
+    //         setValue(e.currentTarget.value);
+    //     } else {
+    //         alert("특수문자는 입력할 수 없습니다.");
+    //         e.currentTarget.value = "";
+    //     }
+    // }
 
     function search(event) {
         if (event.key === "Enter") {
-            if (value.length < 2 || value.length > 20) {
+            if (keyword.length < 2 || keyword.length > 20) {
                 alert("두 글자 이상 스무 글자 이하로 입력하세요.");
                 return;
             }
 
-            console.log("currunt :", event.currentTarget);
-            console.log("event: ", value);
             router.push(
                 {
                     pathname: `/product`,
-                    query: { cat_id: 0, search: value },
+                    query: { cat_id: 0, search: keyword },
                 },
                 `/product`,
             );
-            // setValue("");
-        }
-    }
+            setIndex(-1);
 
-    function keypress(event) {
-        console.log("keypress: ", event.keyCode);
-        if (event.keyCode == 40) {
-            console.log("아래");
-            console.log("target ", inputRef.current);
         }
     }
 
     const autoComplete = async () => {
-        // console.log("auto ",ref.current);
         if (keyword)
             setResource(fetchAutoData(keyword));
     }
 
-    function searchClick(event, name) {
-        setKeyword();
+    function searchClick(name) {
+        inputRef.current.value = name;
+        setKeyword(name);
+
         router.push(
             {
                 pathname: `/product`,
@@ -95,135 +112,142 @@ export default function SearchBar({ value, setValue }) {
             },
             `/product`,
         );
-        // setValue("");
+
+        setIndex(-1);
     }
 
     const data = resource?.ProductNames.read();
 
     return (
         <>
-            {console.log("keyword ", keyword.length)}
             <div className="searchWrapper">
                 <div className="search">
                     <input
+                        ref={inputRef}
                         type="text"
                         size="30"
-                        defaultValue={value}
+                        defaultValue={keyword}
                         placeholder="검색어를 입력해주세요"
                         onChange={(e) => onChangeData(e)}
                         onKeyUp={(event) => {
                             search(event, keyword);
                         }}
-                        onKeyDown={(e) => handleKeyArrow(e)} />
+                        onKeyDown={(e) => handleKeyArrow(e)}
+                        onFocus={(e) => { setOver(true); }}
+                    />
                     <Link href={`/product?search=${keyword}`}>
                         <img src="/common/main_search.png" />
                     </Link>
-                    {keyword.length > 0 ?
+                    {keyword?.length > 0 && over ?
                         <ul className="abs bk" ref={autoRef}>
                             {data?.autoKeyword.length > 0 ?
                                 data?.autoKeyword?.map((productName, idx) => {
                                     return (
                                         productName.includes(keyword) ?
-                                            <li className={index === idx ? "autoName isFocus" : "autoName"} onKeyDown={(e) => keypress(e, productName)} onClick={(e) => search(e, productName)}>
+                                            <li className={index === idx ? "autoName isFocus" : "autoName"}
+                                                onKeyDown={(e) => keypress(e, productName)}
+                                                onClick={() => searchClick(productName)}>
+
                                                 <div className="name">
                                                     {productName.split(keyword)[0]}
                                                     <span className="boldName">{keyword}</span>
                                                     {productName.split(keyword)[1]}
                                                 </div>
                                             </li>
-                                            : <li className="autoName" onClick={(e) => searchClick(e)}><div className="name">{productName}</div></li>
+                                            : <li className={index === idx ? "autoName isFocus" : "autoName"} onClick={() => searchClick(productName)}><div className="name">{productName}</div></li>
                                     )
                                 })
                                 : <li className="autoName">최근 검색결과가 없습니다.</li>}
                         </ul> : ""
                     }
                     <style jsx>{`
-                .search {
-                    position: absolute;
-                    transform: translate(95%, 0%);
-                    background: #fff;
-                    border: 2px solid #ed1b23;
+                        .search {
+                            position: absolute;
+                            transform: translate(95%, 0%);
+                            background: #fff;
+                            border: 2px solid #ed1b23;
 
-                    input[type="text"] {
-                    border: none;
-                    padding: 0;
-                    box-sizing: border-box;
-                    color: #c5c9cd;
-                    font-weight: 600;
-                    }
+                            input[type="text"] {
+                            border: none;
+                            padding: 0;
+                            box-sizing: border-box;
+                            color: #c5c9cd;
+                            font-weight: 600;
+                            }
 
-                    input[type="text"]:focus {
-                    outline: none;
-                    color: #000;
-                    }
+                            input[type="text"]:focus {
+                            outline: none;
+                            color: #000;
+                            }
 
-                    img {
-                    position: relative;
-                    }
-                }
+                            img {
+                            position: relative;
+                            }
+                        }
                         .isFocus{
                             background: #e5e5e5;
                             cursor: pointer;
                         }
                         .bk {
-                        /* border: 1px solid #ed1b23; */
-                        width: 317px;
-                        margin: 0;
-                        padding: 0px;
+                            /* border: 1px solid #ed1b23; */
+                            width: 317px;
+                            margin: 0;
+                            padding: 0px;
                         }
 
                         .contour {
-                        border: 1px solid #ed1b23;
+                            border: 1px solid #ed1b23;
                         }
 
                         .name {
-                        padding: 2px 0px;
+                            padding: 2px 0px;
                         }
 
                         .autoName {
-                        list-style: none;
+                            list-style: none;
                         }
 
                         .autoName:hover {
-                        background: #e5e5e5;
-                        cursor: pointer;
+                            background: #e5e5e5;
+                            cursor: pointer;
                         }
 
                         .boldName {
                             color:#ed1b23; 
                             font-weight:bold;
-                    }
-                                @media screen and (min-width: 769px) {
-                                /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
-                                .searchWrapper {
-                        left: 45%;
-                        top: 35%;
+                        }
+
+                        @media screen and (min-width: 769px) {
+                        /* 데스크탑에서 사용될 스타일을 여기에 작성합니다. */
+                        .searchWrapper {
+                            left: 45%;
+                            top: 35%;
                         }
                         .search {
-                        border-radius: 15px;
-                        padding: 0 17px;
+                            border-radius: 15px;
+                            padding: 0 17px;
 
-                        input[type="text"] {
-                            border-radius: 40px;
-                            width: 317px;
-                            height: 45px;
-                            line-height: 45px;
-                            font-size: 1em;
+                            input[type="text"] {
+                                border-radius: 40px;
+                                width: 317px;
+                                height: 45px;
+                                line-height: 45px;
+                                font-size: 1em;
+                            }
+
+                            img {
+                                width: 24px;
+                                height: 24px;
+                                top: 5px;
+                            }
                         }
 
-                        img {
-                            width: 24px;
-                            height: 24px;
-                            top: 5px;
-                        }
                         }
 
-                                }
-
-                                @media screen and (max-width: 768px) {
-                                /* 태블릿에 사용될 스트일 시트를 여기에 작성합니다. */
-                                }
-                            `}
+                        @media screen and (max-width: 768px) {
+                        /* 태블릿에 사용될 스트일 시트를 여기에 작성합니다. */
+                        }
+                    `}
                     </style>
                 </div>
             </div>

--- a/frontend/pages/product/index.js
+++ b/frontend/pages/product/index.js
@@ -46,7 +46,6 @@ export default function ProductList() {
   useEffect(() => {
     if(search) {
       setKeyword(search);
-      console.log("서치: ",search);
       setResource(fetchSearchData("accuracy", page, search, "", 0, 0, 0, 0));
     }
   },[search]);


### PR DESCRIPTION
## Resolve #220

### 설명
- 키워드를 검색하면 해당 키워드가 포함된 상품명을 자동완성되어 출력합니다.  
- `/api/es/auto`로 요청합니다.
- - 자동완성의 경우 최대 10개까지만 출력합니다.
- 통합검색의 경우 카테고리명, 상품명으로 검색이 이루어지지만,
  자동완성의 경우 상품명에 대한 검색결과를 요구할거라고 생각되어 상품명으로만 접근하여 출력합니다.

![image](https://user-images.githubusercontent.com/99088509/201269644-411f7056-5fca-4458-b77b-b99e16f25d28.png)

![image](https://user-images.githubusercontent.com/99088509/201269701-b385bd34-9b88-4e02-a594-ba79ca6665cf.png)
- 검색바 위치 조정, 키보드 컨트롤 및 마우스 호버시 나타나는 이벤트 동일화가 필요합니다.

### 기타
- url 변경이 필요합니다. (기존 검색과 합친 후 변경 예정)
- 상품명에 대한 출력으로 키워드에 대한 검색어 자동완성으로 개선이 필요해보입니다.

※ 현재 키워드가 변경될 때마다 api를 요청하고 있어 일정초를 기준으로 요청하는 게 더 좋다고 판단되면 수정하도록 하겠습니다.
