### PR TITLE
fix: 배포 환경에서 레디스 오류 해결

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/product/infrastructure/redis/RedisConfig.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/infrastructure/redis/RedisConfig.java
@@ -21,7 +21,7 @@ public class RedisConfig {
     @Bean
     @ConditionalOnMissingBean(RedisConnectionFactory.class)
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory();
+        return new LettuceConnectionFactory(host, port);
     }
 
     @Bean


### PR DESCRIPTION
### 설명
- 레디스 호스트 설정이 제대로 되지 않아 자동으로 `localhost` 로 연결했던 것으로 보입니다.
- 해당 호스트 및 포트 설정 수정했습니다.
- @tlsdnwn55 죄송..