### PR TITLE
feat: 바로결제 페이지 쿠폰 적용 취소 api 구현

### DIFF
--- a/backend/main-service/src/docs/asciidoc/cart_order_review.adoc
+++ b/backend/main-service/src/docs/asciidoc/cart_order_review.adoc
@@ -76,7 +76,7 @@ include::{snippets}/applyCartItemCoupon-success/http-response.adoc[]
 == Order
 === 주문
 
-==== 주문 성공
+=== 주문 성공
 
 - Request
 
@@ -86,7 +86,7 @@ include::{snippets}/product-order-success/http-request.adoc[]
 
 include::{snippets}/product-order-success/http-response.adoc[]
 
-==== 바로결제 페이지 쿠폰 적용
+=== 바로결제 페이지 쿠폰 적용
 
 - Request
 
@@ -96,6 +96,15 @@ include::{snippets}/orders-products-apply-coupon/http-request.adoc[]
 
 include::{snippets}/orders-products-apply-coupon/http-response.adoc[]
 
+=== 바로결제 페이지 쿠폰 적용 취소
+
+- Request
+
+include::{snippets}/orders-products-cancel-coupon/http-request.adoc[]
+
+- Response
+
+include::{snippets}/orders-products-cancel-coupon/http-response.adoc[]
 
 
 == Review

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
@@ -157,7 +157,8 @@ public class OrderService {
         ProductOrderDto productOrderDto, Long couponId) {
         Product product = productRepository.findById(productOrderDto.getProductId())
             .orElseThrow(NotFoundProductException::new);
-        Coupon coupon = couponRepository.findById(couponId).orElseThrow(NotFoundCouponException::new);
+        Coupon coupon = couponRepository.findById(couponId)
+            .orElseThrow(NotFoundCouponException::new);
         Integer discountedPrice = product.getDiscountPrice() - product.getMaxDiscount(coupon);
 
         MemberCoupon memberCoupon = memberCouponRepository.findAllByCouponIdAndMemberId(couponId,
@@ -165,5 +166,11 @@ public class OrderService {
         memberCoupon.applyCoupon();
         return ProductOrderWithCouponDto.create(productOrderDto.getQuantity(), product,
             discountedPrice, coupon);
+    }
+
+    @Transactional
+    public void cancelProductCoupon(Long memberId, Long couponId) {
+        MemberCoupon memberCoupon = memberCouponRepository.findAllByCouponIdAndMemberId(couponId, memberId);
+        memberCoupon.cancelCoupon();
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/ui/OrderController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/ui/OrderController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -63,6 +64,13 @@ public class OrderController {
             loginMember.getId(), productOrderDto, couponId);
 
         return ResponseEntity.status(HttpStatus.OK).body(productOrderWithCouponDto);
+    }
 
+    @PutMapping("/{couponId}")
+    public ResponseEntity<Void> cancelProductCoupon(
+        @PathVariable("couponId") Long couponId,
+        @AuthenticationPrincipal LoginMember loginMember) {
+        orderService.cancelProductCoupon(loginMember.getId(), couponId);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/acceptance/CouponAcceptanceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/acceptance/CouponAcceptanceTest.java
@@ -10,21 +10,16 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import kkakka.mainservice.DocumentConfiguration;
-import kkakka.mainservice.coupon.domain.repository.CouponRepository;
 import kkakka.mainservice.member.auth.ui.dto.SocialProviderCodeRequest;
 import kkakka.mainservice.member.member.domain.ProviderName;
 import kkakka.mainservice.order.application.dto.ProductOrderDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 public class CouponAcceptanceTest extends DocumentConfiguration {
-
-    @Autowired
-    CouponRepository couponRepository;
 
     @DisplayName("등급쿠폰 생성 - 성공")
     @Test
@@ -411,5 +406,41 @@ public class CouponAcceptanceTest extends DocumentConfiguration {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @DisplayName("상품 바로주문 쿠폰 적용 취소 - 성공")
+    @Test
+    void cancelProductCoupon_success() {
+        // given
+        String accessToken = 액세스_토큰_가져옴();
+        String couponId = 바로주문_쿠폰_적용(accessToken);
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured
+            .given(spec).log().all()
+            .filter(document("orders-products-cancel-coupon"))
+            .header("Authorization", "Bearer " + accessToken)
+            .when()
+            .put("/api/orders/" + couponId)
+            .then().log().all().extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private String 바로주문_쿠폰_적용(String accessToken) {
+        String couponId = 상품_쿠폰_다운로드(accessToken);
+        ProductOrderDto productOrderDto = new ProductOrderDto(PRODUCT_1.getId(), 3);
+
+        final ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .header("Authorization", "Bearer " + accessToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(productOrderDto)
+            .when()
+            .post("/api/orders/" + couponId)
+            .then().log().all().extract();
+
+        return couponId;
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
@@ -411,7 +411,7 @@ public class CouponServiceTest extends TestContext {
             null, 2000, 10000
         ));
         couponService.downloadCoupon(couponId, member.getId());
-        orderService.applyProductCoupon(member.getId(), new ProductOrderDto(product.getId(), 2), couponId);
+        orderService.applyProductCoupon(member.getId(), new ProductOrderDto(product.getId(), null, 2), couponId);
 
         // when
         orderService.cancelProductCoupon(member.getId(), couponId);

--- a/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/coupon/application/CouponServiceTest.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import kkakka.mainservice.TestContext;
 import kkakka.mainservice.common.exception.KkaKkaException;
 import kkakka.mainservice.coupon.domain.Coupon;
@@ -22,6 +20,8 @@ import kkakka.mainservice.coupon.ui.dto.CouponResponseDto;
 import kkakka.mainservice.member.member.domain.Grade;
 import kkakka.mainservice.member.member.domain.Member;
 import kkakka.mainservice.member.member.domain.repository.MemberRepository;
+import kkakka.mainservice.order.application.OrderService;
+import kkakka.mainservice.order.application.dto.ProductOrderDto;
 import kkakka.mainservice.product.domain.Product;
 import kkakka.mainservice.product.domain.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -44,6 +44,8 @@ public class CouponServiceTest extends TestContext {
     MemberCouponRepository memberCouponRepository;
     @Autowired
     MemberRepository memberRepository;
+    @Autowired
+    OrderService orderService;
 
     @Test
     @DisplayName("쿠폰 사용 여부 확인 - 성공")
@@ -390,5 +392,32 @@ public class CouponServiceTest extends TestContext {
             }
         }
         assertThat(selectedDto.getIsDownloadable()).isEqualTo(false);
+    }
+
+    @DisplayName("바로결제 쿠폰 적용 취소")
+    @Test
+    void cancelProductCoupon() {
+        // given
+        Product product = new Product(null, null, "product",
+            1000, 20, "", "", "", null);
+        Member member = new Member();
+        productRepository.save(product);
+        memberRepository.save(member);
+        Long couponId = couponService.createCoupon(new CouponRequestDto(
+            null, null, product.getId(),
+            "test", "COUPON",
+            LocalDateTime.of(2020, 3, 16, 3, 16),
+            LocalDateTime.of(2025, 3, 16, 3, 16),
+            null, 2000, 10000
+        ));
+        couponService.downloadCoupon(couponId, member.getId());
+        orderService.applyProductCoupon(member.getId(), new ProductOrderDto(product.getId(), 2), couponId);
+
+        // when
+        orderService.cancelProductCoupon(member.getId(), couponId);
+
+        // then
+        MemberCoupon memberCoupon = memberCouponRepository.findAllByCouponIdAndMemberId(couponId, member.getId());
+        assertThat(memberCoupon.getIsApply()).isEqualTo(false);
     }
 }


### PR DESCRIPTION
## Resolve #261 

### 설명
- 바로결제 페이지에서 `MemberCoupon`에 저장된 `isApply`를 `false` 로 만들어 적용 취소 기능을 적용하였습니다.

![image](https://user-images.githubusercontent.com/34434135/201914499-093a3bee-9d54-479b-9461-3ab7b60c37e3.png)


### 기타
- 프론트와의 상의를 통해 반환값 결정
