### PR TITLE
refactor: 주문한 상품만 장바구니에서 삭제되도록 수정

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/Cart.java
@@ -51,6 +51,10 @@ public class Cart {
         cartItems = new ArrayList<>();
     }
 
+    public void empty(List<CartItem> items) {
+        cartItems.removeAll(items);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/CartItem.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.Objects;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Table(name = "cart_item")
@@ -25,6 +26,7 @@ public class CartItem {
     @JoinColumn(name = "cart_id")
     private Cart cart;
 
+    @BatchSize(size = 10)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;

--- a/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/cart/domain/repository/CartRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
-    @Query("SELECT c FROM Cart c join fetch c.cartItems WHERE c.member.id = :memberId")
+    @Query("SELECT c FROM Cart c join fetch c.cartItems ci join fetch ci.product WHERE c.member.id = :memberId")
     Optional<Cart> findByMemberId(@Param("memberId") Long memberId);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/domain/repository/OrderRepository.java
@@ -21,4 +21,7 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @Query("select sum(o.totalPrice) from Order o where o.member.id = :memberId")
     Optional<Integer> findTotalPriceByMemberId(@Param(value = "memberId") Long memberId);
+
+    @Query("select o from Order o join fetch o.productOrders po join fetch po.product where o.id = :id")
+    Optional<Order> findById(Long id);
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/ui/OrderController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/ui/OrderController.java
@@ -42,7 +42,7 @@ public class OrderController {
                 orderRequest.toRecipientDto(),
                 orderRequest
             ));
-        cartService.emptyCart(loginMember);
+        cartService.emptyCart(loginMember, orderId);
         return ResponseEntity.created(URI.create(orderId.toString())).build();
     }
 

--- a/backend/main-service/src/test/java/kkakka/mainservice/cart/application/CartServiceTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/cart/application/CartServiceTest.java
@@ -2,41 +2,72 @@ package kkakka.mainservice.cart.application;
 
 import static kkakka.mainservice.fixture.TestDataLoader.MEMBER;
 import static kkakka.mainservice.fixture.TestDataLoader.PRODUCT_1;
+import static kkakka.mainservice.fixture.TestDataLoader.PRODUCT_2;
+import static kkakka.mainservice.fixture.TestMember.TEST_MEMBER_01;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
 import kkakka.mainservice.TestContext;
 import kkakka.mainservice.cart.ui.dto.CartRequestDto;
 import kkakka.mainservice.common.auth.Authority;
 import kkakka.mainservice.common.auth.LoginMember;
 import kkakka.mainservice.member.member.domain.Member;
+import kkakka.mainservice.order.application.OrderService;
+import kkakka.mainservice.order.application.dto.OrderDto;
+import kkakka.mainservice.order.application.dto.ProductOrderDto;
+import kkakka.mainservice.order.application.dto.RecipientDto;
+import kkakka.mainservice.order.ui.dto.OrderRequest;
+import kkakka.mainservice.order.ui.dto.RecipientRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 
+@EmbeddedKafka
 @SpringBootTest
 public class CartServiceTest extends TestContext {
 
     @Autowired
     private CartService cartService;
+    @Autowired
+    private OrderService orderService;
 
     @DisplayName("장바구니 비우기 - 성공")
     @Test
     void emptyCart_success() {
         // given
-        CartRequestDto cartRequestDto = new CartRequestDto(PRODUCT_1.getId(), 1);
+        CartRequestDto cartRequestDto1 = new CartRequestDto(PRODUCT_1.getId(), 1);
+        CartRequestDto cartRequestDto2 = new CartRequestDto(PRODUCT_2.getId(), 1);
         Member member = MEMBER;
         LoginMember loginMember = new LoginMember(member.getId(), Authority.MEMBER);
 
-        cartService.addCartItem(cartRequestDto, loginMember);
-        assertThat(cartService.showCartItemCount(loginMember.getId())).isEqualTo(1);
+        cartService.addCartItem(cartRequestDto1, loginMember);
+        cartService.addCartItem(cartRequestDto2, loginMember);
+        assertThat(cartService.showCartItemCount(loginMember.getId())).isEqualTo(2);
+
+        ProductOrderDto productOrderDto1 = new ProductOrderDto(PRODUCT_1.getId(), null, 2);
+        List<ProductOrderDto> productOrderDtos = new ArrayList<>();
+        productOrderDtos.add(productOrderDto1);
+        OrderRequest orderRequest = new OrderRequest(
+                new RecipientRequest(TEST_MEMBER_01.getName(), TEST_MEMBER_01.getEmail(),
+                        TEST_MEMBER_01.getPhone(), TEST_MEMBER_01.getAddress()),
+                productOrderDtos
+        );
+
+        RecipientDto recipientDto = orderRequest.toRecipientDto();
+
+        Long orderId = orderService.order(
+                OrderDto.create(loginMember.getId(), recipientDto, orderRequest)
+        );
 
         // when
-        cartService.emptyCart(loginMember);
+        cartService.emptyCart(loginMember, orderId);
 
         // then
-        assertThat(cartService.showCartItemCount(loginMember.getId())).isEqualTo(0);
+        assertThat(cartService.showCartItemCount(loginMember.getId())).isEqualTo(1);
     }
 
     @DisplayName("장바구니 비우기 - 실패(에러 없음)")
@@ -54,7 +85,7 @@ public class CartServiceTest extends TestContext {
 
         // then
         Assertions.assertThatCode(
-                () -> cartService.emptyCart(wrongLoginMember)
+                () -> cartService.emptyCart(wrongLoginMember, null)
         ).doesNotThrowAnyException();
     }
 }

--- a/backend/main-service/src/test/java/kkakka/mainservice/order/acceptance/ui/OrderControllerMockTest.java
+++ b/backend/main-service/src/test/java/kkakka/mainservice/order/acceptance/ui/OrderControllerMockTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
 
 @SpringBootTest
 public class OrderControllerMockTest extends TestContext {
@@ -48,10 +49,11 @@ public class OrderControllerMockTest extends TestContext {
         LoginMember loginMember = new LoginMember(member.getId(), Authority.MEMBER);
 
         // when
-        orderController.order(loginMember, orderRequest);
+        final ResponseEntity<Void> order = orderController.order(loginMember, orderRequest);
+        final Long orderId = Long.valueOf(order.getHeaders().get("Location").get(0));
 
         // then
         inOrder.verify(mockOrderService, times(1)).order(any());
-        inOrder.verify(mockCartService, times(1)).emptyCart(loginMember);
+        inOrder.verify(mockCartService, times(1)).emptyCart(loginMember, orderId);
     }
 }


### PR DESCRIPTION
## Resolve #280 

### 설명
- 기존에 장바구니에서 전부 삭제해버리던 로직을 주문한 상품만 삭제되도록 수정했습니다.
- 삭제할 때 주문을 한번 조회한 뒤 주문한 상품만 지우는 방식으로 동작합니다.