### PR TITLE
feat. 상품데이터 추가를 위한 설정

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/product/application/dto/NutritionDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/application/dto/NutritionDto.java
@@ -52,9 +52,9 @@ public class NutritionDto {
         );
     }
 
-    public static NutritionDto createEmptyDto(){
+    public static NutritionDto createEmptyDto() {
         return new NutritionDto(
-                0L,"","","","","","","","","",""
+                0L, "", "", "", "", "", "", "", "", "", ""
         );
     }
 }

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/application/dto/NutritionDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/application/dto/NutritionDto.java
@@ -51,5 +51,11 @@ public class NutritionDto {
                 this.calcium
         );
     }
+
+    public static NutritionDto createEmptyDto(){
+        return new NutritionDto(
+                0L,"","","","","","","","","",""
+        );
+    }
 }
 

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/application/dto/ProductDetailDto.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/application/dto/ProductDetailDto.java
@@ -36,7 +36,25 @@ public class ProductDetailDto {
         );
     }
 
+    public static ProductDetailDto toDtoWithoutNutrition(Product product, CategoryDto categoryDto,
+                                         NutritionDto nutritionDto) {
+        return new ProductDetailDto(product.getId(),
+                categoryDto,
+                product.getName(),
+                product.getPrice(),
+                product.getStock(),
+                product.getImageUrl(),
+                product.getDetailImageUrl(),
+                product.getNutritionInfoUrl(),
+                product.getDiscount(),
+                nutritionDto,
+                product.getRatingAvg()
+        );
+    }
+
+
     public ProductDetailResponse toResponseDto() {
+
         return new ProductDetailResponse(
                 this.id,
                 this.categoryDto.toResponseDto(),

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
@@ -82,12 +82,12 @@ public class ProductRepositorySupport extends QuerydslRepositorySupport {
         if("DESC".equals(sortBy)) {
             return new OrderSpecifier<>(Order.DESC, QProduct.product.price);
         }
+//
+//        if("ASC".equals(sortBy)) {
+//            return new OrderSpecifier<>(Order.ASC, QProduct.product.price);
+//        }
 
-        if("ASC".equals(sortBy)) {
-            return new OrderSpecifier<>(Order.ASC, QProduct.product.price);
-        }
-
-        return new OrderSpecifier<Long>(Order.DESC, QProduct.product.id);
+        return new OrderSpecifier<Long>(Order.ASC, QProduct.product.id);
     }
 
     public List<Product> findTopNByKeyword(String keyword) {

--- a/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/product/domain/repository/ProductRepositorySupport.java
@@ -5,8 +5,6 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
-import java.util.Optional;
 import kkakka.mainservice.DataLoader;
 import kkakka.mainservice.category.domain.Category;
 import kkakka.mainservice.category.domain.QCategory;
@@ -17,6 +15,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class ProductRepositorySupport extends QuerydslRepositorySupport {
@@ -79,20 +80,16 @@ public class ProductRepositorySupport extends QuerydslRepositorySupport {
             return new OrderSpecifier<Long>(Order.ASC, QProduct.product.id);
         }
 
-        if("DESC".equals(sortBy)) {
+        if ("DESC".equals(sortBy)) {
             return new OrderSpecifier<>(Order.DESC, QProduct.product.price);
         }
-//
-//        if("ASC".equals(sortBy)) {
-//            return new OrderSpecifier<>(Order.ASC, QProduct.product.price);
-//        }
 
         return new OrderSpecifier<Long>(Order.ASC, QProduct.product.id);
     }
 
     public List<Product> findTopNByKeyword(String keyword) {
         return queryFactory.selectFrom(QProduct.product)
-            .where(QProduct.product.name.contains(keyword))
-            .limit(10).fetch();
+                .where(QProduct.product.name.contains(keyword))
+                .limit(10).fetch();
     }
 }


### PR DESCRIPTION
## Resolve #이슈번호

### 설명
- 영양정보가 없으면 아예 데이터를 들고오질 못해서 없어도 빈 DTO를 생성해서 반환하도록 수정했습니다.
![image](https://user-images.githubusercontent.com/48666403/202322406-4d17889d-1a78-47ad-bfe5-dc7ff29155ec.png)

### 기타
- 없으면 삭제
