### PR TITLE
feat: 주문시 쿠폰 사용 기능 추가 및 쿠폰 사용 api 삭제

### DIFF
--- a/backend/main-service/src/main/java/kkakka/mainservice/coupon/ui/CouponController.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/coupon/ui/CouponController.java
@@ -37,8 +37,8 @@ public class CouponController {
     @AdminOnly
     @PostMapping
     public ResponseEntity<Void> createCoupon(
-            @RequestBody CouponRequestDto couponRequestDto,
-            @AuthenticationPrincipal LoginMember loginMember
+        @RequestBody CouponRequestDto couponRequestDto,
+        @AuthenticationPrincipal LoginMember loginMember
     ) {
         Long couponId = couponService.createCoupon(couponRequestDto);
         return ResponseEntity.created(URI.create(couponId.toString())).build();
@@ -48,8 +48,8 @@ public class CouponController {
     @AdminOnly
     @PutMapping("/{couponId}")
     public ResponseEntity<Void> deleteCouponByAdmin(
-            @PathVariable Long couponId,
-            @AuthenticationPrincipal LoginMember loginMember
+        @PathVariable Long couponId,
+        @AuthenticationPrincipal LoginMember loginMember
     ) {
         couponService.deleteCouponByCouponId(couponId);
         return ResponseEntity.ok().build();
@@ -59,7 +59,7 @@ public class CouponController {
     @AdminOnly
     @GetMapping
     public ResponseEntity<List<CouponResponseDto>> findAllCoupons(
-            @AuthenticationPrincipal LoginMember loginMember
+        @AuthenticationPrincipal LoginMember loginMember
     ) {
         List<CouponResponseDto> couponResponseDto = couponService.showAllCouponsNotDeleted();
         return ResponseEntity.status(HttpStatus.OK).body(couponResponseDto);
@@ -112,8 +112,8 @@ public class CouponController {
     @AdminOnly
     @PostMapping("/discount")
     public ResponseEntity<Long> createDiscount(
-            @RequestBody DiscountRequestDto discountRequestDto,
-            @AuthenticationPrincipal LoginMember loginMember
+        @RequestBody DiscountRequestDto discountRequestDto,
+        @AuthenticationPrincipal LoginMember loginMember
     ) {
         Long discountId = discountService.createDiscount(discountRequestDto);
         return ResponseEntity.created(URI.create(discountId.toString())).build();
@@ -123,8 +123,8 @@ public class CouponController {
     @AdminOnly
     @PutMapping("/discount/{discountId}")
     public ResponseEntity<Void> deleteDiscount(
-            @PathVariable Long discountId,
-            @AuthenticationPrincipal LoginMember loginMember
+        @PathVariable Long discountId,
+        @AuthenticationPrincipal LoginMember loginMember
     ) {
         discountService.deleteDiscount(discountId);
         return ResponseEntity.ok().build();
@@ -134,7 +134,7 @@ public class CouponController {
     @AdminOnly
     @GetMapping("/discount")
     public ResponseEntity<List<DiscountResponseDto>> showAllDiscounts(
-            @AuthenticationPrincipal LoginMember loginMember
+        @AuthenticationPrincipal LoginMember loginMember
     ) {
         List<DiscountResponseDto> discounts = discountService.showAllDiscountsNotDeleted();
         return ResponseEntity.status(HttpStatus.OK).body(discounts);
@@ -157,15 +157,6 @@ public class CouponController {
         List<CouponProductDto> couponResponseDtos = couponService.showCouponsByProductId(
             productId);
         return ResponseEntity.status(HttpStatus.OK).body(couponResponseDtos);
-    }
-
-    /* 쿠폰 사용 */
-    @MemberOnly
-    @PostMapping("/use/{couponId}")
-    public ResponseEntity<Void> useCoupon(@PathVariable Long couponId,
-        @AuthenticationPrincipal LoginMember loginMember) {
-        couponService.useCouponByMember(couponId, loginMember.getId());
-        return ResponseEntity.ok().build();
     }
 
     /* 사용자의 상품 쿠폰 다운로드 */

--- a/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
+++ b/backend/main-service/src/main/java/kkakka/mainservice/order/application/OrderService.java
@@ -75,6 +75,8 @@ public class OrderService {
                     throw new OutOfMinOrderPriceException();
                 }
                 productOrder.applyCoupon(coupon);
+                MemberCoupon memberCoupon = memberCouponRepository.findAllByCouponIdAndMemberId(couponId, memberId);
+                memberCoupon.useCoupon();
             }
             productOrders.add(productOrder);
             orderTotalPrice += productOrder.getTotalPrice();


### PR DESCRIPTION
## Resolve #288 

### 설명
- 주문 시 `MemberCoupon` 찾아서 `isUsed` 를 `true` 로 바꾸었습니다.
- 쿠폰 사용 기능을 추가함에 따라 기존에 테스트를 위해 만들었던 쿠폰 사용 api 를 삭제하였습니다.
- 테스트는 쿠폰 사용 api 대신 주문 api 를 이용하여 진행하였습니다.

