### PR TITLE
feat: 장바구니 상품 종류 제한, 검색필터 변경시 사라지지 않는 문제 해결

### DIFF
--- a/frontend/components/product/SearchFilter.js
+++ b/frontend/components/product/SearchFilter.js
@@ -47,6 +47,12 @@ export default function SearchFilter({ setResource, search, page, cat_id }) {
     searchFilter();
   }, [sort]);
 
+  useEffect(() => {
+    if (!search) {
+      setToggle(false);
+    }
+  }, [search]);
+
   return (
     <div className="SFWrapper">
       <div className="menu">

--- a/frontend/pages/product/productDetail/index.js
+++ b/frontend/pages/product/productDetail/index.js
@@ -82,6 +82,11 @@ export default function ProductDetail({ product, reviewCount }) {
         confirmButtonText: "장바구니 담기",
         cancelButtonText: "취소",
       }).then((result) => {
+        if (cartCnt >= 15) {
+          alert("장바구니 최대 상품 종류는 15개까지입니다.");
+          return;
+        }
+
         if (result.isConfirmed) {
           PostHApi(
             "/api/carts",


### PR DESCRIPTION
## Resolve #296 
장바구니 상품 종류 제한, 검색필터 변경시 사라지지 않는 문제 해결

### 설명
- 장바구니에 담을 수 있는 상품 종류를 15개로 제한했습니다.
- 검색필터 변경시 사라지지 않는 문제를 해결했습니다.